### PR TITLE
Fixing compilation issue, and library formatting

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -19,7 +19,7 @@ import "time"
 // Library version
 //
 
-const Version = "0.0.2"
+const Version = "0.0.3"
 
 //
 // Default API end-point


### PR DESCRIPTION
During installation:

``` go
ivolo:Desktop ivolo$ go get github.com/segmentio/analytics-go
# github.com/segmentio/analytics-go
../dev/src/github.com/segmentio/analytics-go/analytics.go:70: too many arguments in call to uuid.SwitchFormat
```

`uuid.SwitchFormat` seems to have changed signature, so we're removing the second argument, per their [docs](http://godoc.org/github.com/twinj/uuid#SwitchFormat).

Also, `library` should be an object with "name" and "version" so made that change as well.

/cc @visionmedia
