### PR TITLE
Client.send() should not attempt to make an API if no messages

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -220,6 +220,10 @@ func (c *Client) Close() error {
 
 // Send batch request.
 func (c *Client) send(msgs []interface{}) {
+	if len(msgs) == 0 {
+		return
+	}
+	
 	batch := new(Batch)
 	batch.Messages = msgs
 	batch.MessageId = c.uid()


### PR DESCRIPTION
If no messages are passed to Client.send(), then skip the message call altogether.

Wasn't sure how to test this. /cc @tj 