### PR TITLE
Fix: Close() method to wait until all messages was queued and sent

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -309,10 +309,24 @@ func (c *Client) loop() {
 			}
 		case <-c.quit:
 			c.verbose("exit requested – flushing %d", len(msgs))
+			msgs = append(msgs, c.drain(c.msgs))
 			c.send(msgs)
 			c.verbose("exit")
 			c.quit <- true
 			return
+		}
+	}
+}
+
+func (c *Client) drain(ch chan interface{}) []interface{} {
+	msgs := make([]interface{}, 0)
+	for {
+		select {
+		case msg := <-ch:
+			c.verbose("buffer (%d/%d) %v", len(msgs), c.Size, msg)
+			msgs = append(msgs, msg)
+		default:
+			return msgs
 		}
 	}
 }

--- a/analytics.go
+++ b/analytics.go
@@ -222,8 +222,8 @@ func (c *Client) queue(msg message) {
 // Close and flush metrics.
 func (c *Client) Close() error {
 	c.quit <- true
-	close(c.msgs)
 	<-c.quit
+	close(c.msgs)
 	return nil
 }
 


### PR DESCRIPTION
Example which is not working for now:

```
client.Interval = 5 * time.Second
client.Size = 51
client.Verbose = true

for i := 0; i < 50; i++ {
	client.Track(&analytics.Track{
		Event:  "TestKeeen2",
		UserId: "125",
		Properties: map[string]interface{}{
			"application": "Segment Desktop",
			"version":     "1.1.0",
			"platform":    "osx",
		},
	})
	println(i)
}

println("flushing")
client.Close()
```

Before that fix, when ``Close()`` method is call, only a few messages are sending to Segment.io. That is happening because these messages was added in c.msgs channel but ``loop()`` didn't had enough time to process and add it in ``var msgs []interface{}``