### PR TITLE
Revert #28

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -222,8 +222,8 @@ func (c *Client) queue(msg message) {
 // Close and flush metrics.
 func (c *Client) Close() error {
 	c.quit <- true
-	<-c.quit
 	close(c.msgs)
+	<-c.quit
 	return nil
 }
 
@@ -309,24 +309,10 @@ func (c *Client) loop() {
 			}
 		case <-c.quit:
 			c.verbose("exit requested – flushing %d", len(msgs))
-			msgs = append(msgs, c.drain(c.msgs)...)
 			c.send(msgs)
 			c.verbose("exit")
 			c.quit <- true
 			return
-		}
-	}
-}
-
-func (c *Client) drain(ch chan interface{}) []interface{} {
-	msgs := make([]interface{}, 0)
-	for {
-		select {
-		case msg := <-ch:
-			c.verbose("buffer (%d/%d) %v", len(msgs), c.Size, msg)
-			msgs = append(msgs, msg)
-		default:
-			return msgs
 		}
 	}
 }


### PR DESCRIPTION
This reverts #28 and a subsequent fix.

The issue was with this LOC. Once in a while (and likely more often than
not) it would read the same value it sends and exit, instead of
correctly waiting for the flush goroutine to clean up.
```
c.quit <- true
<-c.quit
close(c.msgs)
```

The 2nd commit fixed the #28 implementation, which was incorrectly
appending an array to an array.
```
      msgs = append(msgs, c.drain(c.msgs))
```

This is a combination of 3 commits.
Revert "Append as elements instead of array."

This reverts commit 93892c42c4a95031cda1ed95e796e9f00ff49a44.

Revert "Close msgs after quite is done"

This reverts commit 76b1d6601a237934b023c2941ea55b9ae67d151d.

Revert "Fixed Close method to wait until all msgs was queued"

This reverts commit 4c6a6aecf6eac300f19443ac1aa074f571950c74.