### PR TITLE
Don't deserialize errors

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -1,6 +1,7 @@
 package analytics
 
 import (
+	"io/ioutil"
 	"os"
 
 	"bytes"
@@ -32,12 +33,6 @@ var DefaultContext = map[string]interface{}{
 type message interface {
 	setMessageId(string)
 	setTimestamp(string)
-}
-
-// Response from API.
-type response struct {
-	Message string `json:"message"`
-	Code    string `json:"code"`
 }
 
 // Message fields common to all.
@@ -276,14 +271,14 @@ func (c *Client) report(res *http.Response) {
 		return
 	}
 
-	msg := new(response)
-	err := json.NewDecoder(res.Body).Decode(msg)
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		c.log("error reading response: %s", err)
+		c.log("error reading response body: %s", err)
 		return
 	}
 
-	c.log("response %s: %s – %s", res.Status, msg.Code, msg.Message)
+	c.log("response %s: %s – %s", res.Status, res.StatusCode, body)
 }
 
 // Batch loop.


### PR DESCRIPTION
It's tricky to deserialize HTTP errors since they're not guaranteed
to be in a consistent format.

e.g. failure to publish to NSQ returns "Internal Server Error" instead
of a JSON response.

Alternatively, an error message could be served from the load balancer,
NGINX, etc, in which case it most certainly won't be in the same format
as our API.

Additionally, we don't really need to deserialize the errors, since we
don't take any special action.
Simply reading the response and surfacing the raw body along with the
status and status code should be good enough for our purpose.