### PR TITLE
Fixed resource leak with ticker

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -309,6 +309,7 @@ func (c *Client) loop() {
 				c.verbose("interval reached – nothing to send")
 			}
 		case <-c.quit:
+			tick.Stop()
 			c.verbose("exit requested – draining msgs")
 			// drain the msg channel.
 			for msg := range c.msgs {


### PR DESCRIPTION
Stop the ticker to release associated resources as per the documentation (https://golang.org/pkg/time/#Ticker.Stop)