### PR TITLE
Private configurations using configuration function arguments

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -154,6 +154,8 @@ func New(key string, configs ...ClientConfigFunc) (*Client, error) {
 
 	c.msgs = make(chan interface{}, c.bufferSize)
 
+	c.startLoop()
+
 	return c, nil
 }
 
@@ -235,7 +237,6 @@ func (c *Client) startLoop() {
 
 // Queue message.
 func (c *Client) queue(msg message) {
-	c.once.Do(c.startLoop)
 	msg.setMessageId(c.uid())
 	msg.setTimestamp(timestamp(c.now()))
 	c.msgs <- msg

--- a/analytics.go
+++ b/analytics.go
@@ -1,15 +1,14 @@
 package analytics
 
 import (
-	"io/ioutil"
-	"os"
-	"sync"
-
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"sync"
 	"time"
 
 	"github.com/jehiah/go-strftime"
@@ -17,11 +16,16 @@ import (
 	"github.com/xtgo/uuid"
 )
 
-// Version of the client.
-const Version = "2.1.0"
-
-// Endpoint for the Segment API.
-const Endpoint = "https://api.segment.io"
+const (
+	// Version of the client.
+	Version = "2.1.0"
+	// Endpoint for the Segment API.
+	DefaultEndpoint = "https://api.segment.io"
+	// Number of buffered events before triggering a batch POST
+	DefaultBufferSize = 250
+	// Default flush interval
+	DefaultInterval = 5 * time.Second
+)
 
 // DefaultContext of message batches.
 var DefaultContext = map[string]interface{}{
@@ -32,7 +36,7 @@ var DefaultContext = map[string]interface{}{
 }
 
 // Backoff policy.
-var Backo = backo.DefaultBacko()
+var expBacko = backo.DefaultBacko()
 
 // Message interface.
 type message interface {
@@ -110,41 +114,47 @@ type Alias struct {
 // when the Size limit is exceeded. Set Verbose to true to enable
 // logging output.
 type Client struct {
-	Endpoint string
-	// Interval represents the duration at which messages are flushed. It may be
-	// configured only before any messages are enqueued.
-	Interval time.Duration
-	Size     int
-	Logger   *log.Logger
-	Verbose  bool
-	Client   http.Client
-	key      string
-	msgs     chan interface{}
-	quit     chan struct{}
-	shutdown chan struct{}
-	uid      func() string
-	now      func() time.Time
-	once     sync.Once
+	endpoint string
+	// interval represents the duration at which messages are flushed
+	interval   time.Duration
+	bufferSize int
+	logger     *log.Logger
+	verbose    bool
+	client     *http.Client
+	key        string
+	msgs       chan interface{}
+	quit       chan struct{}
+	shutdown   chan struct{}
+	uid        func() string
+	now        func() time.Time
+	once       sync.Once
 }
 
 // New client with write key.
-func New(key string) *Client {
+func New(key string, configs ...ClientConfigFunc) (*Client, error) {
 	c := &Client{
-		Endpoint: Endpoint,
-		Interval: 5 * time.Second,
-		Size:     250,
-		Logger:   log.New(os.Stderr, "segment ", log.LstdFlags),
-		Verbose:  false,
-		Client:   *http.DefaultClient,
-		key:      key,
-		msgs:     make(chan interface{}, 100),
-		quit:     make(chan struct{}),
-		shutdown: make(chan struct{}),
-		now:      time.Now,
-		uid:      uid,
+		endpoint:   DefaultEndpoint,
+		interval:   DefaultInterval,
+		bufferSize: DefaultBufferSize,
+		logger:     log.New(os.Stderr, "segment ", log.LstdFlags),
+		verbose:    false,
+		client:     http.DefaultClient,
+		key:        key,
+		quit:       make(chan struct{}),
+		shutdown:   make(chan struct{}),
+		now:        time.Now,
+		uid:        uid,
 	}
 
-	return c
+	for _, conf := range configs {
+		if err := conf(c); err != nil {
+			return nil, err
+		}
+	}
+
+	c.msgs = make(chan interface{}, c.bufferSize)
+
+	return c, nil
 }
 
 // Alias buffers an "alias" message.
@@ -261,13 +271,13 @@ func (c *Client) send(msgs []interface{}) {
 		if err := c.upload(b); err == nil {
 			break
 		}
-		Backo.Sleep(i)
+		expBacko.Sleep(i)
 	}
 }
 
 // Upload serialized batch message.
 func (c *Client) upload(b []byte) error {
-	url := c.Endpoint + "/v1/batch"
+	url := c.endpoint + "/v1/batch"
 	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
 	if err != nil {
 		c.logf("error creating request: %s", err)
@@ -279,7 +289,7 @@ func (c *Client) upload(b []byte) error {
 	req.Header.Add("Content-Length", string(len(b)))
 	req.SetBasicAuth(c.key, "")
 
-	res, err := c.Client.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		c.logf("error sending request: %s", err)
 		return err
@@ -294,7 +304,7 @@ func (c *Client) upload(b []byte) error {
 // Report on response body.
 func (c *Client) report(res *http.Response) {
 	if res.StatusCode < 400 {
-		c.verbose("response %s", res.Status)
+		c.verbosef("response %s", res.Status)
 		return
 	}
 
@@ -311,37 +321,37 @@ func (c *Client) report(res *http.Response) {
 // Batch loop.
 func (c *Client) loop() {
 	var msgs []interface{}
-	tick := time.NewTicker(c.Interval)
+	tick := time.NewTicker(c.interval)
 
 	for {
 		select {
 		case msg := <-c.msgs:
-			c.verbose("buffer (%d/%d) %v", len(msgs), c.Size, msg)
+			c.verbosef("buffer (%d/%d) %v", len(msgs), c.bufferSize, msg)
 			msgs = append(msgs, msg)
-			if len(msgs) == c.Size {
-				c.verbose("exceeded %d messages – flushing", c.Size)
+			if len(msgs) == c.bufferSize {
+				c.verbosef("exceeded %d messages – flushing", c.bufferSize)
 				c.send(msgs)
 				msgs = nil
 			}
 		case <-tick.C:
 			if len(msgs) > 0 {
-				c.verbose("interval reached - flushing %d", len(msgs))
+				c.verbosef("interval reached - flushing %d", len(msgs))
 				c.send(msgs)
 				msgs = nil
 			} else {
-				c.verbose("interval reached – nothing to send")
+				c.verbosef("interval reached – nothing to send")
 			}
 		case <-c.quit:
 			tick.Stop()
-			c.verbose("exit requested – draining msgs")
+			c.verbosef("exit requested – draining msgs")
 			// drain the msg channel.
 			for msg := range c.msgs {
-				c.verbose("buffer (%d/%d) %v", len(msgs), c.Size, msg)
+				c.verbosef("buffer (%d/%d) %v", len(msgs), c.bufferSize, msg)
 				msgs = append(msgs, msg)
 			}
-			c.verbose("exit requested – flushing %d", len(msgs))
+			c.verbosef("exit requested – flushing %d", len(msgs))
 			c.send(msgs)
-			c.verbose("exit")
+			c.verbosef("exit")
 			c.shutdown <- struct{}{}
 			return
 		}
@@ -349,15 +359,15 @@ func (c *Client) loop() {
 }
 
 // Verbose log.
-func (c *Client) verbose(msg string, args ...interface{}) {
-	if c.Verbose {
-		c.Logger.Printf(msg, args...)
+func (c *Client) verbosef(msg string, args ...interface{}) {
+	if c.verbose {
+		c.logger.Printf(msg, args...)
 	}
 }
 
 // Unconditional log.
 func (c *Client) logf(msg string, args ...interface{}) {
-	c.Logger.Printf(msg, args...)
+	c.logger.Printf(msg, args...)
 }
 
 // Set message timestamp if one is not already set.

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -1,6 +1,9 @@
 package analytics
 
-import "net/http/httptest"
+import (
+	"net/http/httptest"
+	"testing"
+)
 import "encoding/json"
 import "net/http"
 import "bytes"
@@ -43,11 +46,11 @@ func ExampleTrack() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
-	client.Size = 1
+	client.bufferSize = 1
 
 	client.Track(&Track{
 		Event:  "Download",
@@ -91,8 +94,8 @@ func ExampleClose() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
 
@@ -140,8 +143,8 @@ func ExampleInterval() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
 
@@ -188,11 +191,11 @@ func ExampleTrackWithTimestampSet() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
-	client.Size = 1
+	client.bufferSize = 1
 
 	client.Track(&Track{
 		Event:  "Download",
@@ -239,11 +242,11 @@ func ExampleTrackWithMessageIdSet() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
-	client.Size = 1
+	client.bufferSize = 1
 
 	client.Track(&Track{
 		Event:  "Download",
@@ -290,11 +293,11 @@ func ExampleTrack_context() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
-	client.Size = 1
+	client.bufferSize = 1
 
 	client.Track(&Track{
 		Event:  "Download",
@@ -344,11 +347,11 @@ func ExampleTrack_many() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
-	client.Size = 3
+	client.bufferSize = 3
 
 	for i := 0; i < 5; i++ {
 		client.Track(&Track{
@@ -414,11 +417,11 @@ func ExampleTrackWithIntegrations() {
 	body, server := mockServer()
 	defer server.Close()
 
-	client := New("h97jamjwbh")
-	client.Endpoint = server.URL
+	client, _ := New("h97jamjwbh")
+	client.endpoint = server.URL
 	client.now = mockTime
 	client.uid = mockId
-	client.Size = 1
+	client.bufferSize = 1
 
 	client.Track(&Track{
 		Event:  "Download",
@@ -466,4 +469,10 @@ func ExampleTrackWithIntegrations() {
 	//   "messageId": "I'm unique",
 	//   "sentAt": "2009-11-10T23:00:00+0000"
 	// }
+}
+
+// tests that close actually exits
+func TestCloseFinish(_ *testing.T) {
+	c, _ := New("test")
+	c.Close()
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,72 @@
+package analytics
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type ClientConfigFunc func(*Client) error
+
+// Overwrite the default endpoint 'https://api.segment.io'
+func WithEndpoint(endpoint string) ClientConfigFunc {
+	return func(c *Client) error {
+		if endpoint == "" {
+			return fmt.Errorf("Endpoint: invalid endpoint '%s'", endpoint)
+		}
+		c.endpoint = endpoint
+		return nil
+	}
+}
+
+// Overwrite the default flush interval of 5 seconds
+func WithFlushInterval(interval time.Duration) ClientConfigFunc {
+	return func(c *Client) error {
+		if interval <= 0 {
+			return fmt.Errorf("FlushInterval: invalid interval '%d'", interval)
+		}
+		c.interval = interval
+		return nil
+	}
+}
+
+// Overwrite the default buffersize (Note: Segment will reject payloads larger than 500 KB)
+func WithBufferSize(bufferSize int) ClientConfigFunc {
+	return func(c *Client) error {
+		if bufferSize <= 0 {
+			return fmt.Errorf("BufferSize: invalid bufferSize '%d'", bufferSize)
+		}
+		c.bufferSize = bufferSize
+		return nil
+	}
+}
+
+// Overwrite the default http.DefaultClient
+func WithHttpClient(client *http.Client) ClientConfigFunc {
+	return func(c *Client) error {
+		if client == nil {
+			return errors.New("HttpClient: <nil> client")
+		}
+		c.client = client
+		return nil
+	}
+}
+
+// Overwrite the default logger
+func WithLogger(logger *log.Logger) ClientConfigFunc {
+	return func(c *Client) error {
+		if logger == nil {
+			return errors.New("Logger: <nil> logger")
+		}
+		c.logger = logger
+		return nil
+	}
+}
+
+// Configure client for verbose mode
+func WithVerbosity(c *Client) error {
+	c.verbose = true
+	return nil
+}


### PR DESCRIPTION
Hey segment!

I saw the ongoing work on fixing issue #43 in pull-request #44 and decided to propose my change in the form of my own PR :)

Now, it is a bit of a scope creep, but I also added a ratelimiter with a default of 50 req/sec. This addition and all previous public attributes on the client - `verbose`, `client`, `interval` and `size` and `endpoint` - have been made private and the configuration of these have been replaced with optional configuration functions on the constructor:

```go
type ClientConfigFunc func(*Client) error

New(writekey string, configs ...ClientConfigFunc) (*Client, error) {
    ...
    for _, conf := range configs {
        if err := conf(client); err != nil {
            return nil, err
        }
    }
    ....
}
```

An example of a configuration function is configuring the `FlushInterval`:

```go
// Overwrite the default flush interval of 5 seconds
func FlushInterval(interval time.Duration) ClientConfigFunc {
	return func(c *Client) error {
		if interval <= 0 {
			return fmt.Errorf("FlushInterval: invalid interval '%d'", interval)
		}
		c.interval = interval
		return nil
	}
}
```

And the `New` function, using this configuration would look like so:

```go
client, err := analytics.New("<writekey>", FlushInterval(time.Second * 10))
if err != nil {
   log.Fatal(err)
}
...
```

Inspired by this article by [Rob Pike in 2014](http://commandcenter.blogspot.dk/2014/01/self-referential-functions-and-design.html)