### PR TITLE
Update Circle Config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ build:
 	@godep go build
 
 test:
-	@godep go test -cover ./...
+	@godep go test -race -cover ./...
 
-.PHONY: test deps
+.PHONY: build test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+vet:
+	@godep go vet ./...
+
 build:
 	@godep go build
 
 test:
 	@godep go test -race -cover ./...
 
-.PHONY: build test
+.PHONY: vet build test

--- a/analytics.go
+++ b/analytics.go
@@ -253,7 +253,7 @@ func (c *Client) send(msgs []interface{}) {
 
 	b, err := json.Marshal(batch)
 	if err != nil {
-		c.log("error marshalling msgs: %s", err)
+		c.logf("error marshalling msgs: %s", err)
 		return
 	}
 
@@ -270,7 +270,7 @@ func (c *Client) upload(b []byte) error {
 	url := c.Endpoint + "/v1/batch"
 	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
 	if err != nil {
-		c.log("error creating request: %s", err)
+		c.logf("error creating request: %s", err)
 		return err
 	}
 
@@ -281,7 +281,7 @@ func (c *Client) upload(b []byte) error {
 
 	res, err := c.Client.Do(req)
 	if err != nil {
-		c.log("error sending request: %s", err)
+		c.logf("error sending request: %s", err)
 		return err
 	}
 	defer res.Body.Close()
@@ -301,11 +301,11 @@ func (c *Client) report(res *http.Response) {
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		c.log("error reading response body: %s", err)
+		c.logf("error reading response body: %s", err)
 		return
 	}
 
-	c.log("response %s: %s – %s", res.Status, res.StatusCode, body)
+	c.logf("response %s: %d – %s", res.Status, res.StatusCode, body)
 }
 
 // Batch loop.
@@ -356,7 +356,7 @@ func (c *Client) verbose(msg string, args ...interface{}) {
 }
 
 // Unconditional log.
-func (c *Client) log(msg string, args ...interface{}) {
+func (c *Client) logf(msg string, args ...interface{}) {
 	c.Logger.Printf(msg, args...)
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   pre:
-    - go vet ./...
+    - make vet
 
   override:
     - make test

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,18 @@
+machine:
+  environment:
+    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+
 dependencies:
-  override:
-    - go get -d -t ./...
+  pre:
     - go get github.com/tools/godep
 
+  override:
+    - mkdir -p "$GOPATH/src/$IMPORT_PATH"
+    - rsync -azC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
+
 test:
+  pre:
+    - go vet ./...
+
   override:
     - make test


### PR DESCRIPTION
Makefile: Enable race detector, fix phony targets.

Circle: Clone the repo into our Gopath so circle doesn't fetch master
but actually uses the code in commit.

Go Vet fixes:
1. rename log to logf so go vet isn't confused
2. use %d for response.StatusCode instead of %s