### PR TITLE
add analytics.Logger interface + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Emacs
+*~
+\#*
+.\#*

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/segmentio/analytics-go",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v58",
 	"Packages": [
 		"./..."
 	],
@@ -8,6 +9,10 @@
 		{
 			"ImportPath": "github.com/jehiah/go-strftime",
 			"Rev": "834e15c05a45371503440cc195bbd05c9a0968d9"
+		},
+		{
+			"ImportPath": "github.com/segmentio/backo-go",
+			"Rev": "ed3adc599ae5cd72e97bd085ff1835c9d3276594"
 		},
 		{
 			"ImportPath": "github.com/xtgo/uuid",

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -96,6 +96,8 @@ func TestTrack(t *testing.T) {
 
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 
@@ -152,6 +154,8 @@ func TestTrackWithInterval(t *testing.T) {
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
 	client.Interval = interval
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 
@@ -206,6 +210,8 @@ func TestTrackWithTimestamp(t *testing.T) {
 
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 	client.Size = 1
@@ -259,6 +265,8 @@ func TestTrackWithMessageId(t *testing.T) {
 
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 	client.Size = 1
@@ -312,6 +320,8 @@ func TestTrackWithContext(t *testing.T) {
 
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 	client.Size = 1
@@ -368,6 +378,8 @@ func TestTrackMany(t *testing.T) {
 
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 	client.Size = 3
@@ -440,6 +452,8 @@ func TestTrackWithIntegrations(t *testing.T) {
 
 	client := New("h97jamjwbh")
 	client.Endpoint = server.URL
+	client.Verbose = true
+	client.Logger = t
 	client.now = mockTime
 	client.uid = mockId
 	client.Size = 1

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
 
   override:
     - mkdir -p "$GOPATH/src/$IMPORT_PATH"
-    - rsync -azC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
+    - rsync -razC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,19 @@
-machine:
-  environment:
-    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+#machine:
+#  environment:
+#    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+
+checkout:
+    post:
+      - mkdir -p ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}
+      - ln -sf $(pwd) ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}/$(basename $(pwd))
 
 dependencies:
   pre:
     - go get github.com/tools/godep
 
-  override:
-    - mkdir -p "$GOPATH/src/$IMPORT_PATH"
-    - rsync -razC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
+#  override:
+#    - mkdir -p "$GOPATH/src/$IMPORT_PATH"
+#    - rsync -razC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,3 @@
-#machine:
-#  environment:
-#    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-
 checkout:
     post:
       - mkdir -p ${GOPATH%%:*}/src/github.com/${CIRCLE_PROJECT_USERNAME}
@@ -10,10 +6,6 @@ checkout:
 dependencies:
   pre:
     - go get github.com/tools/godep
-
-#  override:
-#    - mkdir -p "$GOPATH/src/$IMPORT_PATH"
-#    - rsync -razC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
 
 test:
   pre:

--- a/logger.go
+++ b/logger.go
@@ -35,11 +35,11 @@ type stdLogger struct {
 }
 
 func (l stdLogger) Logf(format string, args ...interface{}) {
-	l.logger.Printf("INFO "+format, args...)
+	l.logger.Printf("INFO: "+format, args...)
 }
 
 func (l stdLogger) Errorf(format string, args ...interface{}) {
-	l.logger.Printf("ERROR "+format, args...)
+	l.logger.Printf("ERROR: "+format, args...)
 }
 
 func newDefaultLogger() Logger {

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,47 @@
+package analytics
+
+import (
+	"log"
+	"os"
+)
+
+// Instances of types implementing this interface can be used to define where
+// the analytics client logs are written.
+type Logger interface {
+
+	// Analytics clients call this method to log regular messages about the
+	// operations they perform.
+	// Messages logged by this method are usually tagged with an `INFO` log
+	// level in common logging libraries.
+	Logf(format string, args ...interface{})
+
+	// Analytics clients call this method to log errors they encounter while
+	// sending events to the backend servers.
+	// Messages logged by this method are usually tagged with an `ERROR` log
+	// level in common logging libraries.
+	Errorf(format string, args ...interface{})
+}
+
+// This function instantiate an object that statisfies the analytics.Logger
+// interface and send logs to standard logger passed as argument.
+func StdLogger(logger *log.Logger) Logger {
+	return stdLogger{
+		logger: logger,
+	}
+}
+
+type stdLogger struct {
+	logger *log.Logger
+}
+
+func (l stdLogger) Logf(format string, args ...interface{}) {
+	l.logger.Printf("INFO "+format, args...)
+}
+
+func (l stdLogger) Errorf(format string, args ...interface{}) {
+	l.logger.Printf("ERROR "+format, args...)
+}
+
+func newDefaultLogger() Logger {
+	return StdLogger(log.New(os.Stderr, "segment ", log.LstdFlags))
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -25,9 +25,9 @@ func TestStdLogger(t *testing.T) {
 	logger.Logf("The answer is %d", 42)
 	logger.Errorf("%s", errors.New("something went wrong!"))
 
-	const ref = `test INFO Hello World!
-test INFO The answer is 42
-test ERROR something went wrong!
+	const ref = `test INFO: Hello World!
+test INFO: The answer is 42
+test ERROR: something went wrong!
 `
 
 	if res := buffer.String(); ref != res {

--- a/logger_test.go
+++ b/logger_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // This test ensures that the interface doesn't get changed and stays compatible
-// with the testLogger type.
+// with the *testing.T type.
 // If someone were to modify the interface in backward incompatible manner this
 // test would break.
 func TestTestingLogger(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,63 @@
+package analytics
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+)
+
+type testLogger struct {
+	logs   string
+	errors string
+}
+
+func (t *testLogger) Logf(format string, args ...interface{}) {
+	t.logs += fmt.Sprintf("INFO "+format+"\n", args...)
+}
+
+func (t *testLogger) Errorf(format string, args ...interface{}) {
+	t.errors += fmt.Sprintf("ERROR "+format+"\n", args...)
+}
+
+// This test ensures that the interface doesn't get changed and stays compatible
+// with the testLogger type.
+// If someone were to modify the interface in backward incompatible manner this
+// test would break.
+func TestDummyLogger(t *testing.T) {
+	var tester testLogger
+	var logger Logger = &tester
+
+	logger.Logf("Hello World!")
+	logger.Logf("The answer is %d", 42)
+	logger.Errorf("%s", errors.New("something went wrong!"))
+
+	if tester.logs != "INFO Hello World!\nINFO The answer is 42\n" {
+		t.Error("invalid logs:", tester.logs)
+	}
+
+	if tester.errors != "ERROR something went wrong!\n" {
+		t.Error("invalid errors:", tester.errors)
+	}
+}
+
+// This test ensures the standard logger shim to the Logger interface is working
+// as expected.
+func TestStdLogger(t *testing.T) {
+	var buffer bytes.Buffer
+	var logger = StdLogger(log.New(&buffer, "test ", 0))
+
+	logger.Logf("Hello World!")
+	logger.Logf("The answer is %d", 42)
+	logger.Errorf("%s", errors.New("something went wrong!"))
+
+	const ref = `test INFO Hello World!
+test INFO The answer is 42
+test ERROR something went wrong!
+`
+
+	if res := buffer.String(); ref != res {
+		t.Errorf("invalid logs from standard logger:\n- expected: %s\n- found: %s", ref, res)
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -11,7 +11,7 @@ import (
 // with the testLogger type.
 // If someone were to modify the interface in backward incompatible manner this
 // test would break.
-func TestDummyLogger(t *testing.T) {
+func TestTestingLogger(t *testing.T) {
 	_ = Logger(t)
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -3,43 +3,16 @@ package analytics
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"log"
 	"testing"
 )
-
-type testLogger struct {
-	logs   string
-	errors string
-}
-
-func (t *testLogger) Logf(format string, args ...interface{}) {
-	t.logs += fmt.Sprintf("INFO "+format+"\n", args...)
-}
-
-func (t *testLogger) Errorf(format string, args ...interface{}) {
-	t.errors += fmt.Sprintf("ERROR "+format+"\n", args...)
-}
 
 // This test ensures that the interface doesn't get changed and stays compatible
 // with the testLogger type.
 // If someone were to modify the interface in backward incompatible manner this
 // test would break.
 func TestDummyLogger(t *testing.T) {
-	var tester testLogger
-	var logger Logger = &tester
-
-	logger.Logf("Hello World!")
-	logger.Logf("The answer is %d", 42)
-	logger.Errorf("%s", errors.New("something went wrong!"))
-
-	if tester.logs != "INFO Hello World!\nINFO The answer is 42\n" {
-		t.Error("invalid logs:", tester.logs)
-	}
-
-	if tester.errors != "ERROR something went wrong!\n" {
-		t.Error("invalid errors:", tester.errors)
-	}
+	_ = Logger(t)
 }
 
 // This test ensures the standard logger shim to the Logger interface is working


### PR DESCRIPTION
@f2prateek 
@calvinfo 

Fixes #54 

These changes add the `analytics.Logger` interface to make it easier to plug any logger to instances of `analytics.Client`.

Please take a look and let me know if anything should be changed.