### PR TITLE
add executor to limit the number of goroutines

### DIFF
--- a/error.go
+++ b/error.go
@@ -49,6 +49,10 @@ var (
 	// called after the client was already closed.
 	ErrClosed = errors.New("the client was already closed")
 
+	// This error is used to notify the application that too many requests are
+	// already being sent and no more messages can be accepted.
+	ErrTooManyRequests = errors.New("too many requests are already in-flight")
+
 	// This error is used to notify the client callbacks that a message send
 	// failed because the JSON representation of a message exceeded the upper
 	// limit.

--- a/executor.go
+++ b/executor.go
@@ -1,0 +1,53 @@
+package analytics
+
+import "sync"
+
+type executor struct {
+	queue chan func()
+	mutex sync.Mutex
+	size  int
+	cap   int
+}
+
+func newExecutor(cap int) *executor {
+	e := &executor{
+		queue: make(chan func(), 1),
+		cap:   cap,
+	}
+	go e.loop()
+	return e
+}
+
+func (e *executor) do(task func()) (ok bool) {
+	e.mutex.Lock()
+
+	if e.size != e.cap {
+		e.queue <- task
+		e.size++
+		ok = true
+	}
+
+	e.mutex.Unlock()
+	return
+}
+
+func (e *executor) close() {
+	close(e.queue)
+}
+
+func (e *executor) loop() {
+	for task := range e.queue {
+		go e.run(task)
+	}
+}
+
+func (e *executor) run(task func()) {
+	defer e.done()
+	task()
+}
+
+func (e *executor) done() {
+	e.mutex.Lock()
+	e.size--
+	e.mutex.Unlock()
+}

--- a/executor_test.go
+++ b/executor_test.go
@@ -24,7 +24,7 @@ func TestExecutorSimple(t *testing.T) {
 		return
 	}
 
-	// Make sure wg.Done gets called, this shouldn't block idenfinitely.
+	// Make sure wg.Done gets called, this shouldn't block indefinitely.
 	wg.Wait()
 }
 
@@ -49,6 +49,6 @@ func TestExecutorMulti(t *testing.T) {
 		t.Error("the executor should have been full and refused to run more tasks")
 	}
 
-	// Make sure wg.Done gets called, this shouldn't block idenfinitely.
+	// Make sure wg.Done gets called, this shouldn't block indefinitely.
 	wg.Wait()
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -35,6 +35,8 @@ func TestExecutorMulti(t *testing.T) {
 
 	// Schedule a couple of tasks to fill the executor.
 	for i := 0; i != 3; i++ {
+		wg.Add(1)
+
 		if !ex.do(func() {
 			time.Sleep(10 * time.Millisecond)
 			wg.Done()

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,0 +1,54 @@
+package analytics
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestExecutorClose(t *testing.T) {
+	// Simply make sure that nothing raises a panic nor blocks.
+	ex := newExecutor(1)
+	ex.close()
+}
+
+func TestExecutorSimple(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	ex := newExecutor(1)
+	defer ex.close()
+
+	wg.Add(1)
+
+	if !ex.do(wg.Done) {
+		t.Error("failed pushing a task to an executor with a capacity of 1")
+		return
+	}
+
+	// Make sure wg.Done gets called, this shouldn't block idenfinitely.
+	wg.Wait()
+}
+
+func TestExecutorMulti(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	ex := newExecutor(3)
+	defer ex.close()
+
+	// Schedule a couple of tasks to fill the executor.
+	for i := 0; i != 3; i++ {
+		if !ex.do(func() {
+			time.Sleep(10 * time.Millisecond)
+			wg.Done()
+		}) {
+			t.Error("failed pushing a task to an executor with a capacity of 1")
+			return
+		}
+	}
+
+	// Make sure the executor refuses more tasks.
+	if ex.do(func() {}) {
+		t.Error("the executor should have been full and refused to run more tasks")
+	}
+
+	// Make sure wg.Done gets called, this shouldn't block idenfinitely.
+	wg.Wait()
+}


### PR DESCRIPTION
@f2prateek 

Following up on our conversation and the changes we've made for 2.1.1, this adds the executor concept to limit the number of goroutines being executed.

This is mostly just a cleanup / testable version of what's in 2.1.1, but it calls the failure callback if the executor is full instead of blocking.

Please take a look and let me know if you're OK with the changes!