### PR TITLE
100% test coverage

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -258,7 +258,7 @@ func (c *client) upload(b []byte) error {
 func (c *client) report(res *http.Response) (err error) {
 	var body []byte
 
-	if res.StatusCode < 400 {
+	if res.StatusCode < 300 {
 		c.debugf("response %s", res.Status)
 		return
 	}

--- a/analytics.go
+++ b/analytics.go
@@ -216,10 +216,8 @@ func (c *client) send(msgs []message) {
 		}
 
 		// Wait for either a retry timeout or the client to be closed.
-		c.logf("waiting for retry!")
 		select {
 		case <-time.After(c.RetryAfter(i)):
-			c.logf("retry!")
 		case <-c.quit:
 			c.errorf("%d messages dropped because they failed to be sent and the client was closed", len(msgs))
 			c.notifyFailure(msgs, err)

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -290,6 +290,7 @@ func TestEnqueue(t *testing.T) {
 
 func TestTrackWithInterval(t *testing.T) {
 	const interval = 100 * time.Millisecond
+	var ref = fixture("test-interval-track.json")
 
 	body, server := mockServer()
 	defer server.Close()
@@ -316,31 +317,6 @@ func TestTrackWithInterval(t *testing.T) {
 		},
 	})
 
-	const ref = `{
-  "batch": [
-    {
-      "event": "Download",
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "platform": "osx",
-        "version": "1.1.0"
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    }
-  ],
-  "context": {
-    "library": {
-      "name": "analytics-go",
-      "version": "3.0.0"
-    }
-  },
-  "messageId": "I'm unique",
-  "sentAt": "2009-11-10T23:00:00Z"
-}`
-
 	// Will flush in 100 milliseconds
 	if res := string(<-body); ref != res {
 		t.Errorf("invalid response:\n- expected %s\n- received: %s", ref, res)
@@ -352,6 +328,8 @@ func TestTrackWithInterval(t *testing.T) {
 }
 
 func TestTrackWithTimestamp(t *testing.T) {
+	var ref = fixture("test-timestamp-track.json")
+
 	body, server := mockServer()
 	defer server.Close()
 
@@ -376,37 +354,14 @@ func TestTrackWithTimestamp(t *testing.T) {
 		Timestamp: time.Date(2015, time.July, 10, 23, 0, 0, 0, time.UTC),
 	})
 
-	const ref = `{
-  "batch": [
-    {
-      "event": "Download",
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "platform": "osx",
-        "version": "1.1.0"
-      },
-      "timestamp": "2015-07-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    }
-  ],
-  "context": {
-    "library": {
-      "name": "analytics-go",
-      "version": "3.0.0"
-    }
-  },
-  "messageId": "I'm unique",
-  "sentAt": "2009-11-10T23:00:00Z"
-}`
-
 	if res := string(<-body); ref != res {
 		t.Errorf("invalid response:\n- expected %s\n- received: %s", ref, res)
 	}
 }
 
 func TestTrackWithMessageId(t *testing.T) {
+	var ref = fixture("test-messageid-track.json")
+
 	body, server := mockServer()
 	defer server.Close()
 
@@ -431,37 +386,14 @@ func TestTrackWithMessageId(t *testing.T) {
 		MessageId: "abc",
 	})
 
-	const ref = `{
-  "batch": [
-    {
-      "event": "Download",
-      "messageId": "abc",
-      "properties": {
-        "application": "Segment Desktop",
-        "platform": "osx",
-        "version": "1.1.0"
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    }
-  ],
-  "context": {
-    "library": {
-      "name": "analytics-go",
-      "version": "3.0.0"
-    }
-  },
-  "messageId": "I'm unique",
-  "sentAt": "2009-11-10T23:00:00Z"
-}`
-
 	if res := string(<-body); ref != res {
 		t.Errorf("invalid response:\n- expected %s\n- received: %s", ref, res)
 	}
 }
 
 func TestTrackWithContext(t *testing.T) {
+	var ref = fixture("test-context-track.json")
+
 	body, server := mockServer()
 	defer server.Close()
 
@@ -490,40 +422,14 @@ func TestTrackWithContext(t *testing.T) {
 		},
 	})
 
-	const ref = `{
-  "batch": [
-    {
-      "context": {
-        "whatever": "here"
-      },
-      "event": "Download",
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "platform": "osx",
-        "version": "1.1.0"
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    }
-  ],
-  "context": {
-    "library": {
-      "name": "analytics-go",
-      "version": "3.0.0"
-    }
-  },
-  "messageId": "I'm unique",
-  "sentAt": "2009-11-10T23:00:00Z"
-}`
-
 	if res := string(<-body); ref != res {
 		t.Errorf("invalid response:\n- expected %s\n- received: %s", ref, res)
 	}
 }
 
 func TestTrackMany(t *testing.T) {
+	var ref = fixture("test-many-track.json")
+
 	body, server := mockServer()
 	defer server.Close()
 
@@ -548,58 +454,14 @@ func TestTrackMany(t *testing.T) {
 		})
 	}
 
-	const ref = `{
-  "batch": [
-    {
-      "event": "Download",
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "version": 0
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    },
-    {
-      "event": "Download",
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "version": 1
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    },
-    {
-      "event": "Download",
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "version": 2
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    }
-  ],
-  "context": {
-    "library": {
-      "name": "analytics-go",
-      "version": "3.0.0"
-    }
-  },
-  "messageId": "I'm unique",
-  "sentAt": "2009-11-10T23:00:00Z"
-}`
-
 	if res := string(<-body); ref != res {
 		t.Errorf("invalid response:\n- expected %s\n- received: %s", ref, res)
 	}
 }
 
 func TestTrackWithIntegrations(t *testing.T) {
+	var ref = fixture("test-integrations-track.json")
+
 	body, server := mockServer()
 	defer server.Close()
 
@@ -627,36 +489,6 @@ func TestTrackWithIntegrations(t *testing.T) {
 			"Mixpanel": true,
 		},
 	})
-
-	const ref = `{
-  "batch": [
-    {
-      "event": "Download",
-      "integrations": {
-        "All": true,
-        "Intercom": false,
-        "Mixpanel": true
-      },
-      "messageId": "I'm unique",
-      "properties": {
-        "application": "Segment Desktop",
-        "platform": "osx",
-        "version": "1.1.0"
-      },
-      "timestamp": "2009-11-10T23:00:00Z",
-      "type": "track",
-      "userId": "123456"
-    }
-  ],
-  "context": {
-    "library": {
-      "name": "analytics-go",
-      "version": "3.0.0"
-    }
-  },
-  "messageId": "I'm unique",
-  "sentAt": "2009-11-10T23:00:00Z"
-}`
 
 	if res := string(<-body); ref != res {
 		t.Errorf("invalid response:\n- expected %s\n- received: %s", ref, res)

--- a/config.go
+++ b/config.go
@@ -72,6 +72,12 @@ type Config struct {
 	// This field is not exported and only exposed internally to let unit tests
 	// mock the current time.
 	now func() time.Time
+
+	// The maximum number of goroutines that will be spawned by a client to send
+	// requests to the backend API.
+	// This field is not exported and only exposed internally to let unit tests
+	// mock the current time.
+	maxConcurrentRequests int
 }
 
 // This constant sets the default endpoint to which client instances send
@@ -145,6 +151,10 @@ func makeConfig(c Config) Config {
 
 	if c.now == nil {
 		c.now = time.Now
+	}
+
+	if c.maxConcurrentRequests == 0 {
+		c.maxConcurrentRequests = 1000
 	}
 
 	// We always overwrite the 'library' field of the default context set on the

--- a/context_test.go
+++ b/context_test.go
@@ -13,7 +13,7 @@ func TestContextMarshalJSONLibrary(t *testing.T) {
 	}
 
 	if b, err := json.Marshal(c); err != nil {
-		t.Error("marshaling context object failed:", err)
+		t.Error("marshalling context object failed:", err)
 
 	} else if s := string(b); s != `{"library":{"name":"testing"}}` {
 		t.Error("invalid marshaled representation of context:", s)
@@ -28,7 +28,7 @@ func TestContextMarshalJSONExtra(t *testing.T) {
 	}
 
 	if b, err := json.Marshal(c); err != nil {
-		t.Error("marshaling context object failed:", err)
+		t.Error("marshalling context object failed:", err)
 
 	} else if s := string(b); s != `{"answer":42}` {
 		t.Error("invalid marshaled representation of context:", s)

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,27 @@
+package analytics
+
+import "testing"
+
+func TestConfigError(t *testing.T) {
+	e := ConfigError{
+		Reason: "testing",
+		Field:  "Answer",
+		Value:  42,
+	}
+
+	if s := e.Error(); s != "analytics.NewWithConfig: testing (analytics.Config.Answer: 42)" {
+		t.Error("invalid error message returned by config error:", s)
+	}
+}
+
+func TestFieldError(t *testing.T) {
+	e := FieldError{
+		Type:  "testing.T",
+		Name:  "Answer",
+		Value: 42,
+	}
+
+	if s := e.Error(); s != "testing.T.Answer: invalid field value: 42" {
+		t.Error("invalid error message returned by field error:", s)
+	}
+}

--- a/fixtures/test-context-track.json
+++ b/fixtures/test-context-track.json
@@ -1,0 +1,27 @@
+{
+  "batch": [
+    {
+      "context": {
+        "whatever": "here"
+      },
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "platform": "osx",
+        "version": "1.1.0"
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-enqueue-alias.json
+++ b/fixtures/test-enqueue-alias.json
@@ -1,0 +1,19 @@
+{
+  "batch": [
+    {
+      "messageId": "I'm unique",
+      "previousId": "A",
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "alias",
+      "userId": "B"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-enqueue-group.json
+++ b/fixtures/test-enqueue-group.json
@@ -1,0 +1,19 @@
+{
+  "batch": [
+    {
+      "groupId": "A",
+      "messageId": "I'm unique",
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "group",
+      "userId": "B"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-enqueue-identify.json
+++ b/fixtures/test-enqueue-identify.json
@@ -1,0 +1,18 @@
+{
+  "batch": [
+    {
+      "messageId": "I'm unique",
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "identify",
+      "userId": "B"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-enqueue-page.json
+++ b/fixtures/test-enqueue-page.json
@@ -1,0 +1,19 @@
+{
+  "batch": [
+    {
+      "messageId": "I'm unique",
+      "name": "A",
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "page",
+      "userId": "B"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-enqueue-screen.json
+++ b/fixtures/test-enqueue-screen.json
@@ -1,0 +1,19 @@
+{
+  "batch": [
+    {
+      "messageId": "I'm unique",
+      "name": "A",
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "screen",
+      "userId": "B"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-enqueue-track.json
+++ b/fixtures/test-enqueue-track.json
@@ -1,0 +1,24 @@
+{
+  "batch": [
+    {
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "platform": "osx",
+        "version": "1.1.0"
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-integrations-track.json
+++ b/fixtures/test-integrations-track.json
@@ -1,0 +1,29 @@
+{
+  "batch": [
+    {
+      "event": "Download",
+      "integrations": {
+        "All": true,
+        "Intercom": false,
+        "Mixpanel": true
+      },
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "platform": "osx",
+        "version": "1.1.0"
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-interval-track.json
+++ b/fixtures/test-interval-track.json
@@ -1,0 +1,24 @@
+{
+  "batch": [
+    {
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "platform": "osx",
+        "version": "1.1.0"
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-many-track.json
+++ b/fixtures/test-many-track.json
@@ -1,0 +1,45 @@
+{
+  "batch": [
+    {
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "version": 0
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    },
+    {
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "version": 1
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    },
+    {
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "version": 2
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-messageid-track.json
+++ b/fixtures/test-messageid-track.json
@@ -1,0 +1,24 @@
+{
+  "batch": [
+    {
+      "event": "Download",
+      "messageId": "abc",
+      "properties": {
+        "application": "Segment Desktop",
+        "platform": "osx",
+        "version": "1.1.0"
+      },
+      "timestamp": "2009-11-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/fixtures/test-timestamp-track.json
+++ b/fixtures/test-timestamp-track.json
@@ -1,0 +1,24 @@
+{
+  "batch": [
+    {
+      "event": "Download",
+      "messageId": "I'm unique",
+      "properties": {
+        "application": "Segment Desktop",
+        "platform": "osx",
+        "version": "1.1.0"
+      },
+      "timestamp": "2015-07-10T23:00:00Z",
+      "type": "track",
+      "userId": "123456"
+    }
+  ],
+  "context": {
+    "library": {
+      "name": "analytics-go",
+      "version": "3.0.0"
+    }
+  },
+  "messageId": "I'm unique",
+  "sentAt": "2009-11-10T23:00:00Z"
+}

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -1,0 +1,24 @@
+package analytics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIntegrationsEnableAll(t *testing.T) {
+	i0 := Integrations{"all": true}
+	i1 := NewIntegrations().EnableAll()
+
+	if !reflect.DeepEqual(i0, i1) {
+		t.Errorf("calling EnableAll produced an invalid integration:\n- expected: %#v\n- found: %#v", i0, i1)
+	}
+}
+
+func TestIntegrationsDisableAll(t *testing.T) {
+	i0 := Integrations{"all": false}
+	i1 := NewIntegrations().DisableAll()
+
+	if !reflect.DeepEqual(i0, i1) {
+		t.Errorf("calling DisableAll produced an invalid integration:\n- expected: %#v\n- found: %#v", i0, i1)
+	}
+}

--- a/json_test.go
+++ b/json_test.go
@@ -189,3 +189,15 @@ func TestIsZeroValueStructFalse(t *testing.T) {
 		t.Error("non-empty struct should not be a zero-value")
 	}
 }
+
+func TestIsZeroValueNil(t *testing.T) {
+	if !isZeroValue(reflect.ValueOf(nil)) {
+		t.Error("nil should be a zero-value")
+	}
+}
+
+func TestIsZeroValueFunc(t *testing.T) {
+	if isZeroValue(reflect.ValueOf(func() {})) {
+		t.Error("functions should be be zero-value")
+	}
+}

--- a/message.go
+++ b/message.go
@@ -64,16 +64,13 @@ type message struct {
 }
 
 func makeMessage(m Message, maxBytes int) (msg message, err error) {
-	if msg.json, err = json.Marshal(m); err != nil {
-		return
+	if msg.json, err = json.Marshal(m); err == nil {
+		if len(msg.json) > maxBytes {
+			err = ErrMessageTooBig
+		} else {
+			msg.msg = m
+		}
 	}
-
-	if len(msg.json) > maxBytes {
-		err = ErrMessageTooBig
-		return
-	}
-
-	msg.msg = m
 	return
 }
 

--- a/properties.go
+++ b/properties.go
@@ -68,7 +68,7 @@ func (p Properties) SetProductId(id string) Properties {
 }
 
 func (p Properties) SetOrderId(id string) Properties {
-	return p.Set("id", id)
+	return p.Set("orderId", id)
 }
 
 func (p Properties) SetTotal(total float64) Properties {

--- a/properties_test.go
+++ b/properties_test.go
@@ -1,0 +1,71 @@
+package analytics
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPropertiesSimple(t *testing.T) {
+	text := "ABC"
+	number := 0.5
+	products := []Product{
+		Product{
+			ID:    "1",
+			SKU:   "1",
+			Name:  "A",
+			Price: 42.0,
+		},
+		Product{
+			ID:    "2",
+			SKU:   "2",
+			Name:  "B",
+			Price: 100.0,
+		},
+	}
+
+	tests := map[string]struct {
+		ref Properties
+		run func(Properties)
+	}{
+		"revenue":  {Properties{"revenue": number}, func(p Properties) { p.SetRevenue(number) }},
+		"currency": {Properties{"currency": text}, func(p Properties) { p.SetCurrency(text) }},
+		"value":    {Properties{"value": number}, func(p Properties) { p.SetValue(number) }},
+		"path":     {Properties{"path": text}, func(p Properties) { p.SetPath(text) }},
+		"referrer": {Properties{"referrer": text}, func(p Properties) { p.SetReferrer(text) }},
+		"title":    {Properties{"title": text}, func(p Properties) { p.SetTitle(text) }},
+		"url":      {Properties{"url": text}, func(p Properties) { p.SetURL(text) }},
+		"name":     {Properties{"name": text}, func(p Properties) { p.SetName(text) }},
+		"category": {Properties{"category": text}, func(p Properties) { p.SetCategory(text) }},
+		"sku":      {Properties{"sku": text}, func(p Properties) { p.SetSKU(text) }},
+		"price":    {Properties{"price": number}, func(p Properties) { p.SetPrice(number) }},
+		"id":       {Properties{"id": text}, func(p Properties) { p.SetProductId(text) }},
+		"orderId":  {Properties{"orderId": text}, func(p Properties) { p.SetOrderId(text) }},
+		"total":    {Properties{"total": number}, func(p Properties) { p.SetTotal(number) }},
+		"subtotal": {Properties{"subtotal": number}, func(p Properties) { p.SetSubtotal(number) }},
+		"shipping": {Properties{"shipping": number}, func(p Properties) { p.SetShipping(number) }},
+		"tax":      {Properties{"tax": number}, func(p Properties) { p.SetTax(number) }},
+		"discount": {Properties{"discount": number}, func(p Properties) { p.SetDiscount(number) }},
+		"coupon":   {Properties{"coupon": text}, func(p Properties) { p.SetCoupon(text) }},
+		"products": {Properties{"products": products}, func(p Properties) { p.SetProducts(products...) }},
+		"repeat":   {Properties{"repeat": true}, func(p Properties) { p.SetRepeat(true) }},
+	}
+
+	for name, test := range tests {
+		prop := NewProperties()
+		test.run(prop)
+
+		if !reflect.DeepEqual(prop, test.ref) {
+			t.Errorf("%s: invalid properties produced: %#v\n", name, prop)
+		}
+	}
+}
+
+func TestPropertiesMulti(t *testing.T) {
+	p0 := Properties{"title": "A", "value": 0.5}
+	p1 := NewProperties().SetTitle("A").SetValue(0.5)
+
+	if !reflect.DeepEqual(p0, p1) {
+		t.Errorf("invalid properties produced by chained setters:\n- expected %#v\n- found: %#v", p0, p1)
+	}
+
+}

--- a/traits_test.go
+++ b/traits_test.go
@@ -1,0 +1,52 @@
+package analytics
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTraitsSimple(t *testing.T) {
+	date := time.Now()
+	text := "ABC"
+	number := 42
+
+	tests := map[string](struct {
+		ref Traits
+		run func(Traits)
+	}){
+		"address":     {Traits{"address": text}, func(t Traits) { t.SetAddress(text) }},
+		"age":         {Traits{"age": number}, func(t Traits) { t.SetAge(number) }},
+		"avatar":      {Traits{"avatar": text}, func(t Traits) { t.SetAvatar(text) }},
+		"birthday":    {Traits{"birthday": date}, func(t Traits) { t.SetBirthday(date) }},
+		"createdAt":   {Traits{"createdAt": date}, func(t Traits) { t.SetCreatedAt(date) }},
+		"description": {Traits{"description": text}, func(t Traits) { t.SetDescription(text) }},
+		"email":       {Traits{"email": text}, func(t Traits) { t.SetEmail(text) }},
+		"firstName":   {Traits{"firstName": text}, func(t Traits) { t.SetFirstName(text) }},
+		"lastName":    {Traits{"lastName": text}, func(t Traits) { t.SetLastName(text) }},
+		"gender":      {Traits{"gender": text}, func(t Traits) { t.SetGender(text) }},
+		"name":        {Traits{"name": text}, func(t Traits) { t.SetName(text) }},
+		"phone":       {Traits{"phone": text}, func(t Traits) { t.SetPhone(text) }},
+		"title":       {Traits{"title": text}, func(t Traits) { t.SetTitle(text) }},
+		"username":    {Traits{"username": text}, func(t Traits) { t.SetUsername(text) }},
+		"website":     {Traits{"website": text}, func(t Traits) { t.SetWebsite(text) }},
+	}
+
+	for name, test := range tests {
+		traits := NewTraits()
+		test.run(traits)
+
+		if !reflect.DeepEqual(traits, test.ref) {
+			t.Errorf("%s: invalid traits produced: %#v\n", name, traits)
+		}
+	}
+}
+
+func TestTraitsMulti(t *testing.T) {
+	t0 := Traits{"firstName": "Luke", "lastName": "Skywalker"}
+	t1 := NewTraits().SetFirstName("Luke").SetLastName("Skywalker")
+
+	if !reflect.DeepEqual(t0, t1) {
+		t.Errorf("invalid traits produced by chained setters:\n- expected %#v\n- found: %#v", t0, t1)
+	}
+}


### PR DESCRIPTION
@f2prateek 

This PR adds 100% test coverage for the analytics package:
```
$ go test -cover     
PASS
coverage: 100.0% of statements
ok  	github.com/segmentio/analytics-go	0.202s
```
Going through this process allowed me to find a couple bugs, so it was definitely worth it (one bad key set on Properties, and failure callbacks not being called due to errors being dropped).

This should give us a good base to evolve the package in the future, as well as more confidence when time comes to make this release.

Please take a look and let me know if you see something that should be changed.