### PR TITLE
fix http timeout tests

### DIFF
--- a/analytics_test.go
+++ b/analytics_test.go
@@ -28,6 +28,8 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
+func (f roundTripperFunc) CancelRequest(r *http.Request) {}
+
 // Instances of this type are used to mock the client callbacks in unit tests.
 type testCallback struct {
 	success func(Message)


### PR DESCRIPTION
@f2prateek 

There were issues with Go 1.5 (which Circle-CI is using apparently, despite them saying they're on 1.6), the test HTTP transport did not implement `CancelRequest` which made the HTTP client refuse to send requests after the timeout was set.