### PR TITLE
Set default http timeout conditionally.

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -85,16 +85,23 @@ func NewWithConfig(writeKey string, config Config) (cli Client, err error) {
 		msgs:     make(chan Message, 100),
 		quit:     make(chan struct{}),
 		shutdown: make(chan struct{}),
-		http: http.Client{
-			Transport: config.Transport,
-			Timeout:   10 * time.Second,
-		},
+		http:     makeHttpClient(config.Transport),
 	}
 
 	go c.loop()
 
 	cli = c
 	return
+}
+
+func makeHttpClient(transport http.RoundTripper) http.Client {
+	httpClient := http.Client{
+		Transport: transport,
+	}
+	if supportsTimeout(transport) {
+		httpClient.Timeout = 10 * time.Second
+	}
+	return httpClient
 }
 
 func (c *client) Enqueue(msg Message) (err error) {

--- a/timeout_15.go
+++ b/timeout_15.go
@@ -1,0 +1,16 @@
+// +build !go1.6
+
+package analytics
+
+import "net/http"
+
+// http clients on versions of go before 1.6 only support timeout if the
+// transport implements the `CancelRequest` method.
+func supportsTimeout(transport http.RoundTripper) bool {
+	_, ok := transport.(requestCanceler)
+	return ok
+}
+
+type requestCanceler interface {
+	CancelRequest(*http.Request)
+}

--- a/timeout_16.go
+++ b/timeout_16.go
@@ -1,0 +1,10 @@
+// +build go1.6
+
+package analytics
+
+import "net/http"
+
+// http clients on versions of go after 1.6 always support timeout.
+func supportsTimeout(transport http.RoundTripper) bool {
+	return true
+}


### PR DESCRIPTION
Use conditional compilation to set default timeout on http client.
For go 1.6+ we always the http timeout.
For other older versions, we set the timeout only if the transport
supports it.


cc @achille-roussel 

Closes #105 