### PR TITLE
Adding "DevinceInfo.AdvertisingID" in order to send data to AppsFlyer integration

### DIFF
--- a/context.go
+++ b/context.go
@@ -53,12 +53,13 @@ type CampaignInfo struct {
 // This type provides the representation of the `context.device` object as
 // defined in https://segment.com/docs/spec/common/#context
 type DeviceInfo struct {
-	Id           string `json:"id,omitempty"`
-	Manufacturer string `json:"manufacturer,omitempty"`
-	Model        string `json:"model,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Type         string `json:"type,omitempty"`
-	Version      string `json:"version,omitempty"`
+	Id            string `json:"id,omitempty"`
+	Manufacturer  string `json:"manufacturer,omitempty"`
+	Model         string `json:"model,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Type          string `json:"type,omitempty"`
+	Version       string `json:"version,omitempty"`
+	AdvertisingID string `json:"advertisingId,omitempty"`
 }
 
 // This type provides the representation of the `context.library` object as


### PR DESCRIPTION
Adding "DevinceInfo.AdvertisingID" since it is required in order to send
Server-to-Server events to AppsFlyer according to Segment documentation:
https://segment.com/docs/integrations/appsflyer/#server-side-tracking