### PR TITLE
Resource leak in loop

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -333,6 +333,7 @@ func (c *Client) upload(b []byte) error {
 func (c *Client) loop() {
 	var msgs []interface{}
 	tick := time.NewTicker(c.Interval)
+	defer tick.Stop()
 
 	for {
 		select {


### PR DESCRIPTION
Fixed resource leak on loop ticker.

As per the docs on the ticker: https://golang.org/pkg/time/#NewTicker

> ... Stop the ticker to release associated resources.

This just adds that.