### PR TITLE
Adding `Context.App.Namespace` since it is required in order to send Server-to-Server events to AppsFlyer.

### DIFF
--- a/context.go
+++ b/context.go
@@ -35,9 +35,10 @@ type Context struct {
 // This type provides the representation of the `context.app` object as defined
 // in https://segment.com/docs/spec/common/#context
 type AppInfo struct {
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
-	Build   string `json:"build,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Build     string `json:"build,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // This type provides the representation of the `context.campaign` object as


### PR DESCRIPTION
Adding `Context.App.Namespace` since it is required in order to send Server-to-Server events to AppsFlyer.

This already exists in the Segment iOS SDK:
https://github.com/segmentio/analytics-ios/blob/27e8a7ff9548d74a985c9a16696c41a8115a6202/Analytics/Classes/Internal/SEGSegmentIntegration.m#L154

Segment's own server code for the AppsFlyer-integration according to @TeresaNesteby 

```lang=go
if (deviceType === 'ios') {
    if (device.advertisingId) payload.idfa = device.advertisingId.toString()
    payload.bundle_id = track.proxy('context.app.namespace')
 } else if (device.advertisingId) {
    payload.advertising_id = device.advertisingId.toString()
 }
```

Segment ticket: 86810