### PR TITLE
Add deprecation log

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -152,6 +152,8 @@ func New(key string) *Client {
 		uid:      uid,
 	}
 
+	c.logf("You are currnently using the v2 version analytics-go, which is being deprecated. Please update to v3 as soon as you can https://segment.com/docs/sources/server/go/#migrating-from-v2")
+
 	c.upcond.L = &c.upmtx
 	return c
 }


### PR DESCRIPTION
This prompts users to upgrade to v3 of the library when they initialize the v2 version of the library.

It links them directly to the migration docs at https://segment.com/docs/sources/server/go/#migrating-from-v2

Ref: LIB-287