### PR TITLE
fail when enqueuing invalid message

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -1,6 +1,7 @@
 package analytics
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -148,6 +149,9 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
 		msg = m
+	default:
+		err = errors.New(fmt.Sprintf("Cannot enqueue message with invalid type %T", msg))
+		return
 	}
 
 	defer func() {

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -784,3 +784,12 @@ func TestClientMaxConcurrentRequests(t *testing.T) {
 		t.Errorf("invalid error returned by erroring response body: %T: %s", err, err)
 	}
 }
+
+func TestEnqueuingReferenceFails(t *testing.T) {
+	client := New("0123456789")
+	err := client.Enqueue(&Track{UserId: "A", Event: "B"})
+
+	if err.Error() != "Cannot enqueue message with invalid type *analytics.Track" {
+		t.Errorf("invalid/missing error when queuing invalid message: %T: %s", err, err)
+	}
+}


### PR DESCRIPTION
`client.Enqueue(&msg)` silently fails - I've modified the method to return an error instead.