### PR TITLE
message: update maxMessageBytes to 32KB

### DIFF
--- a/message.go
+++ b/message.go
@@ -124,5 +124,5 @@ func (q *messageQueue) flush() (msgs []message) {
 
 const (
 	maxBatchBytes   = 500000
-	maxMessageBytes = 15000
+	maxMessageBytes = 32000
 )


### PR DESCRIPTION
This patch raises the maxMessageBytes allowed per call to 32KB as stated
in documentation for V3.

> There is a maximum of 500KB per batch request and 32KB per call.

— [segment.com/docs/sources/server/go/#batching](https://segment.com/docs/sources/server/go/#batching)

Closes https://github.com/segmentio/analytics-go/issues/140.