### PR TITLE
return error if a custom type is enqueued

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -186,6 +186,10 @@ func (c *client) Enqueue(msg Message) (err error) {
 		m.MessageId = makeMessageId(m.MessageId, id)
 		m.Timestamp = makeTimestamp(m.Timestamp, ts)
 		msg = m
+
+	default:
+		err = fmt.Errorf("messages with custom types cannot be enqueued: %T", msg)
+		return
 	}
 
 	defer func() {

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -327,6 +327,22 @@ func TestEnqueue(t *testing.T) {
 	}
 }
 
+type customMessage struct {
+}
+
+func (c *customMessage) validate() error {
+	return nil
+}
+
+func TestEnqueuingCustomTypeFails(t *testing.T) {
+	client := New("0123456789")
+	err := client.Enqueue(&customMessage{})
+
+	if err.Error() != "messages with custom types cannot be enqueued: *analytics.customMessage" {
+		t.Errorf("invalid/missing error when queuing unsupported message: %v", err)
+	}
+}
+
 func TestTrackWithInterval(t *testing.T) {
 	const interval = 100 * time.Millisecond
 	var ref = fixture("test-interval-track.json")


### PR DESCRIPTION
Because of the way we construct messages with type assertion, custom types that satisfy the `Message` interface cannot be used.

Normally these would be silently dropped, but this returns an error so that failure is more obvious.