### PR TITLE
change default batch size to 20

### DIFF
--- a/config.go
+++ b/config.go
@@ -90,7 +90,7 @@ const DefaultInterval = 5 * time.Second
 
 // This constant sets the default batch size used by client instances if none
 // was explicitly set.
-const DefaultBatchSize = 250
+const DefaultBatchSize = 20
 
 // Verifies that fields that don't have zero-values are set to valid values,
 // returns an error describing the problem if a field was invalid.


### PR DESCRIPTION
official doc says default batch size is 20
https://segment.com/docs/sources/server/go/#batching.
Using default gives us 400 bad request sometimes.