### PR TITLE
Expose the Message interface Validate method

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -20,6 +20,7 @@ type Alias struct {
 }
 
 func (msg Alias) internal() {
+	panic(unimplementedError)
 }
 
 func (msg Alias) Validate() error {

--- a/alias.go
+++ b/alias.go
@@ -2,6 +2,8 @@ package analytics
 
 import "time"
 
+var _ Message = (*Alias)(nil)
+
 // This type represents object sent in a alias call as described in
 // https://segment.com/docs/libraries/http/#alias
 type Alias struct {
@@ -17,7 +19,10 @@ type Alias struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Alias) validate() error {
+func (msg Alias) internal() {
+}
+
+func (msg Alias) Validate() error {
 	if len(msg.UserId) == 0 {
 		return FieldError{
 			Type:  "analytics.Alias",

--- a/alias_test.go
+++ b/alias_test.go
@@ -7,7 +7,7 @@ func TestAliasMissingUserId(t *testing.T) {
 		PreviousId: "1",
 	}
 
-	if err := alias.validate(); err == nil {
+	if err := alias.Validate(); err == nil {
 		t.Error("validating an invalid alias object succeeded:", alias)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -27,7 +27,7 @@ func TestAliasMissingPreviousId(t *testing.T) {
 		UserId: "1",
 	}
 
-	if err := alias.validate(); err == nil {
+	if err := alias.Validate(); err == nil {
 		t.Error("validating an invalid alias object succeeded:", alias)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -48,7 +48,7 @@ func TestAliasValid(t *testing.T) {
 		UserId:     "2",
 	}
 
-	if err := alias.validate(); err != nil {
+	if err := alias.Validate(); err != nil {
 		t.Error("validating a valid alias object failed:", alias, err)
 	}
 }

--- a/analytics.go
+++ b/analytics.go
@@ -143,7 +143,7 @@ func dereferenceMessage(msg Message) Message {
 
 func (c *client) Enqueue(msg Message) (err error) {
 	msg = dereferenceMessage(msg)
-	if err = msg.validate(); err != nil {
+	if err = msg.Validate(); err != nil {
 		return
 	}
 

--- a/analytics.go
+++ b/analytics.go
@@ -14,6 +14,7 @@ import (
 
 // Version of the client.
 const Version = "3.0.0"
+const unimplementedError = "not implemented"
 
 // This interface is the main API exposed by the analytics package.
 // Values that satsify this interface are returned by the client constructors

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -66,11 +66,15 @@ func (l testLogger) Errorf(format string, args ...interface{}) {
 	}
 }
 
+var _ Message = (*testErrorMessage)(nil)
 // Instances of this type are used to force message validation errors in unit
 // tests.
 type testErrorMessage struct{}
 
-func (m testErrorMessage) validate() error { return testError }
+func (m testErrorMessage) internal() {
+}
+
+func (m testErrorMessage) Validate() error { return testError }
 
 var (
 	// A control error returned by mock functions to emulate a failure.
@@ -327,10 +331,15 @@ func TestEnqueue(t *testing.T) {
 	}
 }
 
+var _ Message = (*customMessage)(nil)
+
 type customMessage struct {
 }
 
-func (c *customMessage) validate() error {
+func (c *customMessage) internal() {
+}
+
+func (c *customMessage) Validate() error {
 	return nil
 }
 

--- a/group.go
+++ b/group.go
@@ -22,6 +22,7 @@ type Group struct {
 }
 
 func (msg Group) internal() {
+	panic(unimplementedError)
 }
 
 func (msg Group) Validate() error {

--- a/group.go
+++ b/group.go
@@ -2,6 +2,8 @@ package analytics
 
 import "time"
 
+var _ Message = (*Group)(nil)
+
 // This type represents object sent in a group call as described in
 // https://segment.com/docs/libraries/http/#group
 type Group struct {
@@ -19,7 +21,10 @@ type Group struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Group) validate() error {
+func (msg Group) internal() {
+}
+
+func (msg Group) Validate() error {
 	if len(msg.GroupId) == 0 {
 		return FieldError{
 			Type:  "analytics.Group",

--- a/group_test.go
+++ b/group_test.go
@@ -7,7 +7,7 @@ func TestGroupMissingGroupId(t *testing.T) {
 		UserId: "1",
 	}
 
-	if err := group.validate(); err == nil {
+	if err := group.Validate(); err == nil {
 		t.Error("validating an invalid group object succeeded:", group)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -27,7 +27,7 @@ func TestGroupMissingUserId(t *testing.T) {
 		GroupId: "1",
 	}
 
-	if err := group.validate(); err == nil {
+	if err := group.Validate(); err == nil {
 		t.Error("validating an invalid group object succeeded:", group)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -48,7 +48,7 @@ func TestGroupValidWithUserId(t *testing.T) {
 		UserId:  "2",
 	}
 
-	if err := group.validate(); err != nil {
+	if err := group.Validate(); err != nil {
 		t.Error("validating a valid group object failed:", group, err)
 	}
 }
@@ -59,7 +59,7 @@ func TestGroupValidWithAnonymousId(t *testing.T) {
 		AnonymousId: "2",
 	}
 
-	if err := group.validate(); err != nil {
+	if err := group.Validate(); err != nil {
 		t.Error("validating a valid group object failed:", group, err)
 	}
 }

--- a/identify.go
+++ b/identify.go
@@ -2,6 +2,8 @@ package analytics
 
 import "time"
 
+var _ Message = (*Identify)(nil)
+
 // This type represents object sent in an identify call as described in
 // https://segment.com/docs/libraries/http/#identify
 type Identify struct {
@@ -18,7 +20,10 @@ type Identify struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Identify) validate() error {
+func (msg Identify) internal() {
+}
+
+func (msg Identify) Validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{
 			Type:  "analytics.Identify",

--- a/identify.go
+++ b/identify.go
@@ -21,6 +21,7 @@ type Identify struct {
 }
 
 func (msg Identify) internal() {
+	panic(unimplementedError)
 }
 
 func (msg Identify) Validate() error {

--- a/identify_test.go
+++ b/identify_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestIdentifyMissingUserId(t *testing.T) {
 	identify := Identify{}
 
-	if err := identify.validate(); err == nil {
+	if err := identify.Validate(); err == nil {
 		t.Error("validating an invalid identify object succeeded:", identify)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -25,7 +25,7 @@ func TestIdentifyValidWithUserId(t *testing.T) {
 		UserId: "2",
 	}
 
-	if err := identify.validate(); err != nil {
+	if err := identify.Validate(); err != nil {
 		t.Error("validating a valid identify object failed:", identify, err)
 	}
 }
@@ -35,7 +35,7 @@ func TestIdentifyValidWithAnonymousId(t *testing.T) {
 		AnonymousId: "2",
 	}
 
-	if err := identify.validate(); err != nil {
+	if err := identify.Validate(); err != nil {
 		t.Error("validating a valid identify object failed:", identify, err)
 	}
 }

--- a/message.go
+++ b/message.go
@@ -37,7 +37,7 @@ type Message interface {
 	// nil if the message is valid, or an error describing what went wrong.
 	Validate() error
 
-	// internal is an unexposed interface function to ensure only Message types defined within this package are usable.
+	// internal is an unexposed interface function to ensure only types defined within this package can satisfy the Message interface. Invoking this method will panic.
 	internal()
 }
 

--- a/message.go
+++ b/message.go
@@ -33,9 +33,12 @@ type Callback interface {
 // and therefore can be passed to the analytics.Client.Send method.
 type Message interface {
 
-	// Validates the internal structure of the message, the method must return
+	// Validate validates the internal structure of the message, the method must return
 	// nil if the message is valid, or an error describing what went wrong.
-	validate() error
+	Validate() error
+
+	// internal is an unexposed interface function to ensure only Message types defined within this package are usable.
+	internal()
 }
 
 // Takes a message id as first argument and returns it, unless it's the zero-

--- a/page.go
+++ b/page.go
@@ -2,6 +2,8 @@ package analytics
 
 import "time"
 
+var _ Message = (*Page)(nil)
+
 // This type represents object sent in a page call as described in
 // https://segment.com/docs/libraries/http/#page
 type Page struct {
@@ -19,7 +21,10 @@ type Page struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Page) validate() error {
+func (msg Page) internal() {
+}
+
+func (msg Page) Validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{
 			Type:  "analytics.Page",

--- a/page.go
+++ b/page.go
@@ -22,6 +22,7 @@ type Page struct {
 }
 
 func (msg Page) internal() {
+	panic(unimplementedError)
 }
 
 func (msg Page) Validate() error {

--- a/page_test.go
+++ b/page_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestPageMissingUserId(t *testing.T) {
 	page := Page{}
 
-	if err := page.validate(); err == nil {
+	if err := page.Validate(); err == nil {
 		t.Error("validating an invalid page object succeeded:", page)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -25,7 +25,7 @@ func TestPageValidWithUserId(t *testing.T) {
 		UserId: "2",
 	}
 
-	if err := page.validate(); err != nil {
+	if err := page.Validate(); err != nil {
 		t.Error("validating a valid page object failed:", page, err)
 	}
 }
@@ -35,7 +35,7 @@ func TestPageValidWithAnonymousId(t *testing.T) {
 		AnonymousId: "2",
 	}
 
-	if err := page.validate(); err != nil {
+	if err := page.Validate(); err != nil {
 		t.Error("validating a valid page object failed:", page, err)
 	}
 }

--- a/screen.go
+++ b/screen.go
@@ -22,6 +22,7 @@ type Screen struct {
 }
 
 func (msg Screen) internal() {
+	panic(unimplementedError)
 }
 
 func (msg Screen) Validate() error {

--- a/screen.go
+++ b/screen.go
@@ -2,6 +2,8 @@ package analytics
 
 import "time"
 
+var _ Message = (*Screen)(nil)
+
 // This type represents object sent in a screen call as described in
 // https://segment.com/docs/libraries/http/#screen
 type Screen struct {
@@ -19,7 +21,10 @@ type Screen struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Screen) validate() error {
+func (msg Screen) internal() {
+}
+
+func (msg Screen) Validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{
 			Type:  "analytics.Screen",

--- a/screen_test.go
+++ b/screen_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestScreenMissingUserId(t *testing.T) {
 	screen := Screen{}
 
-	if err := screen.validate(); err == nil {
+	if err := screen.Validate(); err == nil {
 		t.Error("validating an invalid screen object succeeded:", screen)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -25,7 +25,7 @@ func TestScreenValidWithUserId(t *testing.T) {
 		UserId: "2",
 	}
 
-	if err := screen.validate(); err != nil {
+	if err := screen.Validate(); err != nil {
 		t.Error("validating a valid screen object failed:", screen, err)
 	}
 }
@@ -35,7 +35,7 @@ func TestScreenValidWithAnonymousId(t *testing.T) {
 		AnonymousId: "2",
 	}
 
-	if err := screen.validate(); err != nil {
+	if err := screen.Validate(); err != nil {
 		t.Error("validating a valid screen object failed:", screen, err)
 	}
 }

--- a/track.go
+++ b/track.go
@@ -22,7 +22,7 @@ type Track struct {
 }
 
 func (msg Track) internal() {
-	panic("implement me")
+	panic(unimplementedError)
 }
 
 func (msg Track) Validate() error {

--- a/track.go
+++ b/track.go
@@ -2,6 +2,8 @@ package analytics
 
 import "time"
 
+var _ Message = (*Track)(nil)
+
 // This type represents object sent in a track call as described in
 // https://segment.com/docs/libraries/http/#track
 type Track struct {
@@ -19,7 +21,11 @@ type Track struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Track) validate() error {
+func (msg Track) internal() {
+	panic("implement me")
+}
+
+func (msg Track) Validate() error {
 	if len(msg.Event) == 0 {
 		return FieldError{
 			Type:  "analytics.Track",

--- a/track_test.go
+++ b/track_test.go
@@ -7,7 +7,7 @@ func TestTrackMissingEvent(t *testing.T) {
 		UserId: "1",
 	}
 
-	if err := track.validate(); err == nil {
+	if err := track.Validate(); err == nil {
 		t.Error("validating an invalid track object succeeded:", track)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -27,7 +27,7 @@ func TestTrackMissingUserId(t *testing.T) {
 		Event: "1",
 	}
 
-	if err := track.validate(); err == nil {
+	if err := track.Validate(); err == nil {
 		t.Error("validating an invalid track object succeeded:", track)
 
 	} else if e, ok := err.(FieldError); !ok {
@@ -48,7 +48,7 @@ func TestTrackValidWithUserId(t *testing.T) {
 		UserId: "2",
 	}
 
-	if err := track.validate(); err != nil {
+	if err := track.Validate(); err != nil {
 		t.Error("validating a valid track object failed:", track, err)
 	}
 }
@@ -59,7 +59,7 @@ func TestTrackValidWithAnonymousId(t *testing.T) {
 		AnonymousId: "2",
 	}
 
-	if err := track.validate(); err != nil {
+	if err := track.Validate(); err != nil {
 		t.Error("validating a valid track object failed:", track, err)
 	}
 }


### PR DESCRIPTION
By exposing the Message interfaces validate() method it allows the
analytics types to be used externally in other code and not confined to
the analytics-go library.