### PR TITLE
[BUG] Incorrect string to int conversion

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strconv"
 	"sync"
 
 	"bytes"
@@ -291,7 +292,7 @@ func (c *client) upload(b []byte) error {
 
 	req.Header.Add("User-Agent", "analytics-go (version: "+Version+")")
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Content-Length", string(len(b)))
+	req.Header.Add("Content-Length", strconv.Itoa(len(b)))
 	req.SetBasicAuth(c.key, "")
 
 	res, err := c.http.Do(req)


### PR DESCRIPTION
The `string(10)` returns Unicode character using this Unicode number, instead of "10" as it was expected here.


This conversion `string(int(10))` doesn't compile in Go 1.15. 