### PR TITLE
Remove message internal-only restriction and add ValidateFields

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -19,10 +19,6 @@ type Alias struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Alias) internal() {
-	panic(unimplementedError)
-}
-
 func (msg Alias) Validate() error {
 	if len(msg.UserId) == 0 {
 		return FieldError{

--- a/analytics.go
+++ b/analytics.go
@@ -15,7 +15,6 @@ import (
 
 // Version of the client.
 const Version = "3.0.0"
-const unimplementedError = "not implemented"
 
 // This interface is the main API exposed by the analytics package.
 // Values that satsify this interface are returned by the client constructors

--- a/analytics.go
+++ b/analytics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strconv"
 	"sync"
 
 	"bytes"
@@ -291,7 +292,7 @@ func (c *client) upload(b []byte) error {
 
 	req.Header.Add("User-Agent", "analytics-go (version: "+Version+")")
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Content-Length", string(len(b)))
+	req.Header.Add("Content-Length", strconv.Itoa(len(b)))
 	req.SetBasicAuth(c.key, "")
 
 	res, err := c.http.Do(req)

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -67,12 +67,10 @@ func (l testLogger) Errorf(format string, args ...interface{}) {
 }
 
 var _ Message = (*testErrorMessage)(nil)
+
 // Instances of this type are used to force message validation errors in unit
 // tests.
 type testErrorMessage struct{}
-
-func (m testErrorMessage) internal() {
-}
 
 func (m testErrorMessage) Validate() error { return testError }
 
@@ -334,9 +332,6 @@ func TestEnqueue(t *testing.T) {
 var _ Message = (*customMessage)(nil)
 
 type customMessage struct {
-}
-
-func (c *customMessage) internal() {
 }
 
 func (c *customMessage) Validate() error {

--- a/group.go
+++ b/group.go
@@ -21,10 +21,6 @@ type Group struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Group) internal() {
-	panic(unimplementedError)
-}
-
 func (msg Group) Validate() error {
 	if len(msg.GroupId) == 0 {
 		return FieldError{

--- a/identify.go
+++ b/identify.go
@@ -20,10 +20,6 @@ type Identify struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Identify) internal() {
-	panic(unimplementedError)
-}
-
 func (msg Identify) Validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{

--- a/message.go
+++ b/message.go
@@ -36,9 +36,6 @@ type Message interface {
 	// Validate validates the internal structure of the message, the method must return
 	// nil if the message is valid, or an error describing what went wrong.
 	Validate() error
-
-	// internal is an unexposed interface function to ensure only types defined within this package can satisfy the Message interface. Invoking this method will panic.
-	internal()
 }
 
 // Takes a message id as first argument and returns it, unless it's the zero-

--- a/page.go
+++ b/page.go
@@ -21,10 +21,6 @@ type Page struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Page) internal() {
-	panic(unimplementedError)
-}
-
 func (msg Page) Validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{

--- a/screen.go
+++ b/screen.go
@@ -21,10 +21,6 @@ type Screen struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Screen) internal() {
-	panic(unimplementedError)
-}
-
 func (msg Screen) Validate() error {
 	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
 		return FieldError{

--- a/track.go
+++ b/track.go
@@ -21,10 +21,6 @@ type Track struct {
 	Integrations Integrations `json:"integrations,omitempty"`
 }
 
-func (msg Track) internal() {
-	panic(unimplementedError)
-}
-
 func (msg Track) Validate() error {
 	if len(msg.Event) == 0 {
 		return FieldError{

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,56 @@
+package analytics
+
+func getString(msg map[string]interface{}, field string) string {
+	val, _ := msg[field].(string)
+	return val
+}
+
+func ValidateFields(msg map[string]interface{}) error {
+	if typ, ok := msg["type"].(string); ok {
+		switch typ {
+		case "alias":
+			return Alias{
+				Type:       "alias",
+				UserId:     getString(msg, "userId"),
+				PreviousId: getString(msg, "previousId"),
+			}.Validate()
+		case "group":
+			return Group{
+				Type:        "group",
+				UserId:      getString(msg, "userId"),
+				AnonymousId: getString(msg, "anonymousId"),
+				GroupId:     getString(msg, "groupId"),
+			}.Validate()
+		case "identify":
+			return Identify{
+				Type:        "identify",
+				UserId:      getString(msg, "userId"),
+				AnonymousId: getString(msg, "anonymousId"),
+			}.Validate()
+		case "page":
+			return Page{
+				Type:        "page",
+				UserId:      getString(msg, "userId"),
+				AnonymousId: getString(msg, "anonymousId"),
+			}.Validate()
+		case "screen":
+			return Screen{
+				Type:        "screen",
+				UserId:      getString(msg, "userId"),
+				AnonymousId: getString(msg, "anonymousId"),
+			}.Validate()
+		case "track":
+			return Track{
+				Type:        "track",
+				UserId:      getString(msg, "userId"),
+				AnonymousId: getString(msg, "anonymousId"),
+				Event:       getString(msg, "event"),
+			}.Validate()
+		}
+	}
+	return FieldError{
+		Type:  "analytics.Event",
+		Name:  "Type",
+		Value: msg["type"],
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -1,13 +1,22 @@
 package analytics
 
-func getString(msg map[string]interface{}, field string) string {
-	val, _ := msg[field].(string)
-	return val
+type FieldGetter interface {
+	GetField(field string) (interface{}, bool)
 }
 
-func ValidateFields(msg map[string]interface{}) error {
-	if typ, ok := msg["type"].(string); ok {
-		switch typ {
+func getString(msg FieldGetter, field string) string {
+	if val, ok := msg.GetField(field); ok {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+func ValidateFields(msg FieldGetter) error {
+	typ, _ := msg.GetField("type")
+	if str, ok := typ.(string); ok {
+		switch str {
 		case "alias":
 			return Alias{
 				Type:       "alias",
@@ -51,6 +60,6 @@ func ValidateFields(msg map[string]interface{}) error {
 	return FieldError{
 		Type:  "analytics.Event",
 		Name:  "Type",
-		Value: msg["type"],
+		Value: typ,
 	}
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,343 @@
+package analytics
+
+import (
+	"reflect"
+	"testing"
+)
+
+var _ Message = (Event)(nil)
+
+type Event map[string]interface{}
+
+func (e Event) Validate() error {
+	return ValidateFields(e)
+}
+
+func TestValidateFieldsMissingType(t *testing.T) {
+	msg := Event{
+		"userId": "user123",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Event",
+		Name:  "Type",
+		Value: nil,
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsInvalidType(t *testing.T) {
+	msg := Event{
+		"type":   "invalid",
+		"userId": "user123",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Event",
+		Name:  "Type",
+		Value: "invalid",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsAlias(t *testing.T) {
+	msg := Event{
+		"type":       "alias",
+		"userId":     "user123",
+		"previousId": "user456",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic alias message:", err)
+	}
+}
+
+func TestValidateFieldsAliasInvalid(t *testing.T) {
+	msg := Event{
+		"type":   "alias",
+		"userId": "user123",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Alias",
+		Name:  "PreviousId",
+		Value: "",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsGroup(t *testing.T) {
+	msg := Event{
+		"type":    "group",
+		"userId":  "user123",
+		"groupId": "group1",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic group message:", err)
+	}
+}
+
+func TestValidateFieldsGroupAnonymous(t *testing.T) {
+	msg := Event{
+		"type":        "group",
+		"anonymousId": "user123",
+		"groupId":     "group1",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic group message:", err)
+	}
+}
+
+func TestValidateFieldsGroupInvalid(t *testing.T) {
+	msg := Event{
+		"type":   "group",
+		"userId": "user123",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Group",
+		Name:  "GroupId",
+		Value: "",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsIdentify(t *testing.T) {
+	msg := Event{
+		"type":   "identify",
+		"userId": "user123",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic identify message:", err)
+	}
+}
+
+func TestValidateFieldsIdentifyAnonymous(t *testing.T) {
+	msg := Event{
+		"type":        "identify",
+		"anonymousId": "user123",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic identify message:", err)
+	}
+}
+
+func TestValidateFieldsIdentifyInvalid(t *testing.T) {
+	msg := Event{
+		"type": "identify",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Identify",
+		Name:  "UserId",
+		Value: "",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsPage(t *testing.T) {
+	msg := Event{
+		"type":   "page",
+		"userId": "user123",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic page message:", err)
+	}
+}
+
+func TestValidateFieldsPageAnonymous(t *testing.T) {
+	msg := Event{
+		"type":        "page",
+		"anonymousId": "user123",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic page message:", err)
+	}
+}
+
+func TestValidateFieldsPageInvalid(t *testing.T) {
+	msg := Event{
+		"type": "page",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Page",
+		Name:  "UserId",
+		Value: "",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsScreen(t *testing.T) {
+	msg := Event{
+		"type":   "screen",
+		"userId": "user123",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic screen message:", err)
+	}
+}
+
+func TestValidateFieldsScreenAnonymous(t *testing.T) {
+	msg := Event{
+		"type":        "screen",
+		"anonymousId": "user123",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic screen message:", err)
+	}
+}
+
+func TestValidateFieldsScreenInvalid(t *testing.T) {
+	msg := Event{
+		"type": "screen",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Screen",
+		Name:  "UserId",
+		Value: "",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsTrack(t *testing.T) {
+	msg := Event{
+		"type":   "track",
+		"userId": "user123",
+		"event":  "testing",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic track message:", err)
+	}
+}
+
+func TestValidateFieldsTrackAnonymous(t *testing.T) {
+	msg := Event{
+		"type":        "track",
+		"anonymousId": "user123",
+		"event":       "testing",
+	}
+	if err := msg.Validate(); err != nil {
+		t.Error("error returned when validating a generic track message:", err)
+	}
+}
+
+func TestValidateFieldsTrackInvalid(t *testing.T) {
+	msg := Event{
+		"type":   "track",
+		"userId": "user123",
+	}
+
+	if err := msg.Validate(); err == nil {
+		t.Error("validating an invalid generic message succeeded:", msg)
+	} else if e, ok := err.(FieldError); !ok {
+		t.Error("invalid error type returned when validating a generic message:", err)
+
+	} else if e != (FieldError{
+		Type:  "analytics.Track",
+		Name:  "Event",
+		Value: "",
+	}) {
+		t.Error("invalid error type returned when validating a generic message:", err)
+	}
+}
+
+func TestValidateFieldsQueuePushMaxBatchSize(t *testing.T) {
+	m0, _ := makeMessage(Event{
+		"type":   "track",
+		"userId": "1",
+		"event":  "A",
+	}, maxMessageBytes)
+
+	m1, _ := makeMessage(Event{
+		"type":   "track",
+		"userId": "2",
+		"event":  "A",
+	}, maxMessageBytes)
+
+	q := messageQueue{
+		maxBatchSize:  2,
+		maxBatchBytes: maxBatchBytes,
+	}
+
+	if msgs := q.push(m0); msgs != nil {
+		t.Error("unexpected message batch returned after pushing only one message")
+	}
+
+	if msgs := q.push(m1); !reflect.DeepEqual(msgs, []message{m0, m1}) {
+		t.Error("invalid message batch returned after pushing two messages:", msgs)
+	}
+}
+
+func TestValidateFieldsQueuePushMaxBatchBytes(t *testing.T) {
+	m0, _ := makeMessage(Event{
+		"type":   "track",
+		"UserId": "1",
+		"Event":  "A",
+	}, maxMessageBytes)
+
+	m1, _ := makeMessage(Event{
+		"type":   "track",
+		"UserId": "2",
+		"Event":  "A",
+	}, maxMessageBytes)
+
+	q := messageQueue{
+		maxBatchSize:  100,
+		maxBatchBytes: len(m0.json) + 1,
+	}
+
+	if msgs := q.push(m0); msgs != nil {
+		t.Error("unexpected message batch returned after pushing only one message")
+	}
+
+	if msgs := q.push(m1); !reflect.DeepEqual(msgs, []message{m0}) {
+		t.Error("invalid message batch returned after pushing two messages:", msgs)
+	}
+
+	if !reflect.DeepEqual(q.pending, []message{m1}) {
+		t.Error("invalid state of the message queue after pushing two messages:", q.pending)
+	}
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -6,11 +6,17 @@ import (
 )
 
 var _ Message = (Event)(nil)
+var _ FieldGetter = (Event)(nil)
 
 type Event map[string]interface{}
 
 func (e Event) Validate() error {
 	return ValidateFields(e)
+}
+
+func (e Event) GetField(field string) (val interface{}, ok bool) {
+	val, ok = e[field]
+	return
 }
 
 func TestValidateFieldsMissingType(t *testing.T) {
@@ -73,7 +79,6 @@ func TestValidateFieldsAliasInvalid(t *testing.T) {
 		t.Error("validating an invalid generic message succeeded:", msg)
 	} else if e, ok := err.(FieldError); !ok {
 		t.Error("invalid error type returned when validating a generic message:", err)
-
 	} else if e != (FieldError{
 		Type:  "analytics.Alias",
 		Name:  "PreviousId",


### PR DESCRIPTION
This change removes the `internal()` method requirement for the `Message` interface. This is added so that only internal types may implement the `Message` interface. However, we have a need in two of our services to implement a custom message type with less restrictive value requirements. The `Validate()` method of the various event types in this library enforce encoding fields with stricter values then are required by the Tracking API. For some of our internal services that invoke the Tracking API, we need to match the flexibility it provides. By removing the `internal()` requirement, we can implement our own `Message` that matches these expectations.

Additionally, this defines a `ValidateFields(map[string]interface{}) error` function. This verifies that the input contains an accepted event type specifier, and then passes minimally required fields into the type-specific validation. This can then be used to validate and/or construct a `Message` object in the other services that need to maintain full Tracking API compatibility (`webhook-functions-consumer`, `platform-api`, etc.)

A prior attempt at this was to define another, more flexible `Message` implementation in PR #163. We need to move ahead with either of these two PRs.

Additionally, this fixes some code that needs to convert an `int` into a `string` when adding a header.