### PR TITLE
Add Context.Direct

### DIFF
--- a/context.go
+++ b/context.go
@@ -20,6 +20,7 @@ type Context struct {
 	Referrer  ReferrerInfo `json:"referrer,omitempty"`
 	Screen    ScreenInfo   `json:"screen,omitempty"`
 	IP        net.IP       `json:"ip,omitempty"`
+	Direct    bool         `json:"direct,omitempty"`
 	Locale    string       `json:"locale,omitempty"`
 	Timezone  string       `json:"timezone,omitempty"`
 	UserAgent string       `json:"userAgent,omitempty"`


### PR DESCRIPTION
Fixes #171 

Adds the `direct` field to context, which can be used when using the analytics-go package in a client application to avoid having to set the IP address on the client side.

