### PR TITLE
Issue #176 - Read the entire http response body after sending a message.

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -311,6 +311,10 @@ func (c *client) report(res *http.Response) (err error) {
 
 	if res.StatusCode < 300 {
 		c.debugf("response %s", res.Status)
+		// http.Do expectes us to not only close but also fully read the response
+		// otherwise the Client's underlying RoundTripper may not be able to re-use a persistent TCP
+		// connection to the server for a subsequent "keep-alive" request.
+                ioutil.ReadAll(res.Body)
 		return
 	}
 


### PR DESCRIPTION
Make sure that even when response status is <300 that we fully read the response body.

The http.Do function documentation states that:

// If the returned error is nil, the Response will contain a non-nil
// Body which the user is expected to close. If the Body is not both
// read to EOF and closed, the Client's underlying RoundTripper
// (typically Transport) may not be able to re-use a persistent TCP
// connection to the server for a subsequent "keep-alive" request.