### PR TITLE
Add group id to context

### DIFF
--- a/context.go
+++ b/context.go
@@ -22,6 +22,7 @@ type Context struct {
 	IP        net.IP       `json:"ip,omitempty"`
 	Direct    bool         `json:"direct,omitempty"`
 	Locale    string       `json:"locale,omitempty"`
+	GroupID   string       `json:"groupId,omitempty"`
 	Timezone  string       `json:"timezone,omitempty"`
 	UserAgent string       `json:"userAgent,omitempty"`
 	Traits    Traits       `json:"traits,omitempty"`


### PR DESCRIPTION
Add group id to context so the track events can related to both a user and distinct id and group.