### PR TITLE
Fix go get import path in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ versions of the library.
 
 To install it in the GOPATH:
 ```
-go get https://github.com/segmentio/analytics-go
+go get github.com/segmentio/analytics-go
 ```
 
 ## Documentation


### PR DESCRIPTION
Fixes the `go get` command in the README; the HTTPS protocol scheme must not be included.

This is the output when running the command as currently specified:

```
 > go get https://github.com/segmentio/analytics-go
go: malformed module path "https:/github.com/segmentio/analytics-go": invalid char ':'
```