### PR TITLE
Add Token in DeviceInfo

### DIFF
--- a/context.go
+++ b/context.go
@@ -57,6 +57,7 @@ type CampaignInfo struct {
 // defined in https://segment.com/docs/spec/common/#context
 type DeviceInfo struct {
 	Id            string `json:"id,omitempty"`
+	Token        string `json:"token,omitempty"`
 	Manufacturer  string `json:"manufacturer,omitempty"`
 	Model         string `json:"model,omitempty"`
 	Name          string `json:"name,omitempty"`

--- a/context.go
+++ b/context.go
@@ -57,7 +57,7 @@ type CampaignInfo struct {
 // defined in https://segment.com/docs/spec/common/#context
 type DeviceInfo struct {
 	Id            string `json:"id,omitempty"`
-	Token        string `json:"token,omitempty"`
+	Token         string `json:"token,omitempty"`
 	Manufacturer  string `json:"manufacturer,omitempty"`
 	Model         string `json:"model,omitempty"`
 	Name          string `json:"name,omitempty"`


### PR DESCRIPTION
Token is needed for some destinations and it exists in [Spec: Common Fields](https://segment.com/docs/connections/spec/common/#structure)