### PR TITLE
Harden CI: Artifactory OIDC, fork-aware workflows, SHA-pinned actions

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -57,7 +57,8 @@ runs:
 
         if [ -z "$ART_TOKEN" ]; then
           echo "::error::OIDC token exchange failed."
-          echo "$RESP" | jq 'if .access_token then .access_token="<redacted>" else . end' 2>/dev/null || echo "$RESP"
+          echo "$RESP" | jq 'walk(if type == "object" then with_entries(if (.key | test("token"; "i")) then .value = "<redacted>" else . end) else . end)' 2>/dev/null \
+            || echo "::error::(response withheld — not valid JSON)"
           exit 1
         fi
         echo "::add-mask::$ART_TOKEN"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -9,7 +9,7 @@ inputs:
   oidc-provider-name:
     description: "OIDC provider name configured in Artifactory"
     required: false
-    default: "github-actions"
+    default: "github-actions-segmentio"
   go-repo:
     description: "Artifactory virtual Go repository name"
     required: false
@@ -38,6 +38,13 @@ runs:
         if [ -z "$OIDC_JWT" ] || [ "$OIDC_JWT" = "null" ]; then
           echo "::error::Failed to obtain GitHub OIDC token"; exit 1
         fi
+
+        decode_seg() { local s="${1}"; local m=$(( ${#s} % 4 )); [ $m -ne 0 ] && s="${s}$(printf '=%.0s' $(seq 1 $((4-m))))"; echo "$s" | tr '_-' '/+' | base64 -d 2>/dev/null; }
+        PAYLOAD=$(decode_seg "$(echo "$OIDC_JWT" | cut -d. -f2)")
+        echo "OIDC token claims:"
+        echo "  sub = $(echo "$PAYLOAD" | jq -r '.sub')"
+        echo "  aud = $(echo "$PAYLOAD" | jq -r '.aud')"
+        echo "  iss = $(echo "$PAYLOAD" | jq -r '.iss')"
 
         RESP=$(curl -sS "${ARTIFACTORY_URL}/access/api/v1/oidc/token" \
           -H 'Content-Type: application/json' \

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -1,0 +1,65 @@
+name: "Artifactory OIDC Auth"
+description: "Exchange GitHub OIDC token for Artifactory access token and configure GOPROXY"
+
+inputs:
+  artifactory-url:
+    description: "Base Artifactory platform URL. Falls back to ARTIFACTORY_URL env var."
+    required: false
+    default: ""
+  oidc-provider-name:
+    description: "OIDC provider name configured in Artifactory"
+    required: false
+    default: "github-actions"
+  go-repo:
+    description: "Artifactory virtual Go repository name"
+    required: false
+    default: "virtual-go-thirdparty"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Exchange GitHub OIDC token for Artifactory token
+      shell: bash
+      env:
+        INPUT_ARTIFACTORY_URL: ${{ inputs.artifactory-url }}
+        OIDC_PROVIDER_NAME: ${{ inputs.oidc-provider-name }}
+        GO_REPO: ${{ inputs.go-repo }}
+      run: |
+        set -euo pipefail
+        ARTIFACTORY_URL="${INPUT_ARTIFACTORY_URL:-${ARTIFACTORY_URL:-}}"
+        if [ -z "${ARTIFACTORY_URL}" ]; then
+          echo "::error::ARTIFACTORY_URL is not set (pass as input or set as env var)"; exit 1
+        fi
+
+        OIDC_JWT=$(curl -sS \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${ARTIFACTORY_URL}" \
+          -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" | jq -r '.value')
+
+        if [ -z "$OIDC_JWT" ] || [ "$OIDC_JWT" = "null" ]; then
+          echo "::error::Failed to obtain GitHub OIDC token"; exit 1
+        fi
+
+        RESP=$(curl -sS "${ARTIFACTORY_URL}/access/api/v1/oidc/token" \
+          -H 'Content-Type: application/json' \
+          -d "{\"grant_type\":\"urn:ietf:params:oauth:grant-type:token-exchange\",
+               \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\",
+               \"subject_token\":\"${OIDC_JWT}\",
+               \"provider_name\":\"${OIDC_PROVIDER_NAME}\"}")
+
+        ART_TOKEN=$(echo "$RESP" | jq -r '.access_token // empty')
+
+        if [ -z "$ART_TOKEN" ]; then
+          echo "::error::OIDC token exchange failed."
+          echo "$RESP" | jq 'if .access_token then .access_token="<redacted>" else . end' 2>/dev/null || echo "$RESP"
+          exit 1
+        fi
+        echo "::add-mask::$ART_TOKEN"
+
+        HOST=$(echo "${ARTIFACTORY_URL}" | sed -E 's#^https?://##')
+        GOPROXY_URL="https://:${ART_TOKEN}@${HOST}/artifactory/api/go/${GO_REPO},direct"
+
+        echo "::add-mask::${GOPROXY_URL}"
+        echo "GOPROXY=${GOPROXY_URL}" >> "$GITHUB_ENV"
+        echo "GONOSUMDB=*" >> "$GITHUB_ENV"
+        echo "GONOSUMCHECK=*" >> "$GITHUB_ENV"
+        echo "Configured GOPROXY to resolve through Artifactory (${GO_REPO})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,31 +6,63 @@ on:
   pull_request:
     branches: [v3.0]
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ['1.21', '1.22', '1.23']
+  vet:
+    name: Vet & Lint
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.24"
+
+      - name: Authenticate to Artifactory
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Download dependencies
-        run: go get -v -t ./...
+        run: go mod download
 
       - name: Vet
         run: go vet ./...
 
+  test:
+    name: Test (Go ${{ matrix.go-version }})
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.22", "1.23", "1.24"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Authenticate to Artifactory
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
+
+      - name: Download dependencies
+        run: go mod download
+
       - name: Test
-        run: go test -race -coverprofile=cover.out .
+        run: go test -race -coverprofile=cover.out ./...
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -38,3 +70,29 @@ jobs:
           name: coverage-go${{ matrix.go-version }}
           path: cover.out
           retention-days: 7
+
+  build:
+    name: Build Verification
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: "1.24"
+
+      - name: Authenticate to Artifactory
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Verify module
+        run: go mod verify
+
+      - name: Build
+        run: go build ./...

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,27 +12,33 @@ on:
         required: false
         default: 'main'
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   e2e-tests:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-x64
 
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: sdk
 
       - name: Checkout sdk-e2e-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: segmentio/sdk-e2e-tests
           ref: ${{ inputs.e2e_tests_ref || 'main' }}
-          token: ${{ secrets.E2E_TESTS_TOKEN }}
           path: sdk-e2e-tests
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: sdk/go.mod
 
@@ -40,6 +46,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Authenticate to Artifactory
+        uses: ./sdk/.github/actions/artifactory-oidc
 
       - name: Build e2e-cli
         working-directory: sdk/e2e-cli

--- a/.github/workflows/publish-e2e-cli.yml
+++ b/.github/workflows/publish-e2e-cli.yml
@@ -12,17 +12,27 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: go.mod
+
+      - name: Authenticate to Artifactory
+        uses: ./.github/actions/artifactory-oidc
 
       - name: Build e2e-cli
         working-directory: e2e-cli


### PR DESCRIPTION
## Summary

- Add Artifactory OIDC composite action — exchanges GitHub OIDC token for short-lived Artifactory access token, sets \`GOPROXY\` to \`virtual-go-thirdparty\`
- Replace \`ci.yml\` — fork-aware runner selection, Go 1.22–1.24 matrix, vet/test/build jobs, SHA-pinned actions
- Update \`e2e-tests.yml\` + \`publish-e2e-cli.yml\` — remove \`E2E_TESTS_TOKEN\` (sdk-e2e-tests going public), fork-aware, SHA-pinned

## Notes

- No deploy workflow needed — Go publishes via git tags to the module proxy automatically
- \`go.sum\` already committed; Go's integrity model is lockfile-equivalent

## Test plan

- [ ] CI runs on this PR
- [ ] Artifactory OIDC exchange succeeds on same-repo CI
- [ ] Before merging: set \`ARTIFACTORY_URL\` repository variable